### PR TITLE
chore: add workspace deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,11 @@ members = [
 	"crates/uniffi-bindgen", "tools/cargo-bin",
 ]
 
+[workspace.dependencies]
+uniffi = { version = "0.28.3" }
+thiserror = { version = "2.0.7" }
+wasm-bindgen = { version = "0.2.99" }
+tsify-next = { version = "0.5.4", features = ["js"] }
+
 [workspace.metadata.bin]
 polytest = { version = "0.3.0", locked = true }

--- a/crates/algokit_transact/Cargo.toml
+++ b/crates/algokit_transact/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1.0.216", features = ["derive"] }
 serde_json = "1.0.133"
 serde_with = "3.11.0"
 sha2 = "0.10.8"
-thiserror = "2.0.7"
+thiserror = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/crates/algokit_transact_ffi/Cargo.toml
+++ b/crates/algokit_transact_ffi/Cargo.toml
@@ -15,24 +15,24 @@ ffi_uniffi = ["dep:uniffi"]
 algokit_transact = { path = "../algokit_transact" }
 ffi_macros = { path = "../ffi_macros" }
 
-thiserror = "2.0.7"
+thiserror = { workspace = true }
 rmp-serde = "1.3.0"
 serde = { version = "1.0.216", features = ["derive"] }
 serde_bytes = "0.11.15"
 
-tsify-next = { version = "0.5.4", features = ["js"], optional = true }
-uniffi = { version = "0.28.3", features = [
+tsify-next = { workspace = true, optional = true }
+uniffi = { workspace = true, features = [
     "scaffolding-ffi-buffer-fns",
 ], optional = true }
-wasm-bindgen = { version = "0.2.99", optional = true }
+wasm-bindgen = { workspace = true, optional = true }
 
 
 [dev-dependencies]
 wasm-pack = "0.13.1"
-uniffi = { version = "0.28.3", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }
 
 [build-dependencies]
-uniffi = { version = "0.28.3", features = [
+uniffi = { workspace = true, features = [
     "build",
     "scaffolding-ffi-buffer-fns", # Add the "scaffolding-ffi-buffer-fns" feature to make sure things can build correctly
 ] }

--- a/crates/uniffi-bindgen/Cargo.toml
+++ b/crates/uniffi-bindgen/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-uniffi = {version = "0.28.3", features = ["cli"]}
+uniffi = { workspace = true, features = ["cli"]}


### PR DESCRIPTION
This will help ensure all crates use these same versions. There may be other crates we want to add here, but for now I focued on the FFI-related crates
