### PR TITLE
feat: added txnid ffi endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,9 @@ name = "algokit_transact_ffi"
 version = "0.1.0"
 dependencies = [
  "algokit_transact",
+ "base64",
  "ffi_macros",
+ "pretty_assertions",
  "rmp-serde",
  "serde",
  "serde_bytes",

--- a/crates/algokit_transact_ffi/Cargo.toml
+++ b/crates/algokit_transact_ffi/Cargo.toml
@@ -25,6 +25,8 @@ uniffi = { workspace = true, features = [
     "scaffolding-ffi-buffer-fns",
 ], optional = true }
 wasm-bindgen = { workspace = true, optional = true }
+base64 = "0.22.1"
+pretty_assertions = "1.4.1"
 
 
 [dev-dependencies]


### PR DESCRIPTION
~~This PR is dependent on #52. Will move out of draft mode, once it's merged.~~

This PR adds the FFI implementation of the the newly added `txn.id` and `txn.raw_id` methods. 