### PR TITLE
chore: temporarily disable swift

### DIFF
--- a/.github/workflows/swift_ci.yml
+++ b/.github/workflows/swift_ci.yml
@@ -1,14 +1,15 @@
 name: Swift CI
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - "*"
-  pull_request:
-    branches:
-      - main
+  # Temporarily disable automatic CI for swift while we focus on Python and TS
+  # push:
+  #   branches:
+  #     - main
+  #   tags:
+  #     - "*"
+  # pull_request:
+  #   branches:
+  #     - main
   workflow_dispatch:
 
 permissions:

--- a/crates/algokit_transact_ffi/polytest.toml
+++ b/crates/algokit_transact_ffi/polytest.toml
@@ -61,16 +61,17 @@ out_dir = "../../packages/typescript/algokit_transact/__tests__"
 [target.pytest]
 out_dir = "../../packages/python/algokit_transact/tests"
 
-[target.swift]
-out_dir = "../../packages/swift/AlgoKitTransact/Tests/AlgoKitTransactTests"
-
-# The default runner is macOS, which defines most of what we need
-# The iOS and Catalyst runners will inherit all the configuration from the default macOS runner, except for the command we defined
-[target.swift.runner.iOS]
-command = "xcodebuild -scheme {{ package_name | convert_case('Pascal') }} test -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest'"
-
-[target.swift.runner.Catalyst]
-command = "xcodebuild -scheme {{ package_name | convert_case('Pascal') }} test -destination 'platform=macOS,variant=Mac Catalyst'"
+# Temporarily comment out swift while we focus on Python and TypeScript
+# [target.swift]
+# out_dir = "../../packages/swift/AlgoKitTransact/Tests/AlgoKitTransactTests"
+#
+# # The default runner is macOS, which defines most of what we need
+# # The iOS and Catalyst runners will inherit all the configuration from the default macOS runner, except for the command we defined
+# [target.swift.runner.iOS]
+# command = "xcodebuild -scheme {{ package_name | convert_case('Pascal') }} test -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest'"
+#
+# [target.swift.runner.Catalyst]
+# command = "xcodebuild -scheme {{ package_name | convert_case('Pascal') }} test -destination 'platform=macOS,variant=Mac Catalyst'"
 
 # Document
 

--- a/scripts/build/index.ts
+++ b/scripts/build/index.ts
@@ -82,6 +82,7 @@ if (!crates.includes(crate)) {
 if (language === "all") {
   await Promise.all(
     Object.keys(languages).map(async (language) => {
+      if (language === "swift") return; // temporarily remove swift from "all" while we focus on python and typescript
       await languages[language](crate);
     }),
   );


### PR DESCRIPTION
Disables swift from build script, CI, and polytest while we focus on Python and TypeScript. Main goal is to reduce noise and CI time.