### PR TITLE
chore: adding ts and py test for transaction id

### DIFF
--- a/crates/algokit_transact_ffi/polytest.toml
+++ b/crates/algokit_transact_ffi/polytest.toml
@@ -50,6 +50,9 @@ desc = "A transaction without TX prefix and valid fields is decoded properly"
 [group."Transaction Tests".test."get encoded transaction type"]
 desc = "The transaction type of an encoded transaction can be retrieved"
 
+[group."Transaction Tests".test."get transaction id"]
+desc = "A transaction id can be obtained from a transaction"
+
 [group."Transaction Tests".test.example]
 desc = "A human-readable example of forming a transaction and signing it"
 
@@ -77,4 +80,3 @@ out_dir = "../../packages/python/algokit_transact/tests"
 
 [document.markdown]
 out_file = "test_plan.md"
-

--- a/crates/algokit_transact_ffi/test_plan.md
+++ b/crates/algokit_transact_ffi/test_plan.md
@@ -31,6 +31,7 @@
 | [decode with prefix](#decode-with-prefix) | A transaction with TX prefix and valid fields is decoded properly |
 | [decode without prefix](#decode-without-prefix) | A transaction without TX prefix and valid fields is decoded properly |
 | [get encoded transaction type](#get-encoded-transaction-type) | The transaction type of an encoded transaction can be retrieved |
+| [get transaction id](#get-transaction-id) | A transaction id can be obtained from a transaction |
 | [example](#example) | A human-readable example of forming a transaction and signing it |
 
 ## Test Cases
@@ -62,6 +63,10 @@ A transaction without TX prefix and valid fields is decoded properly
 ### get encoded transaction type
 
 The transaction type of an encoded transaction can be retrieved
+
+### get transaction id
+
+A transaction id can be obtained from a transaction
 
 ### example
 

--- a/packages/python/algokit_transact/tests/test_payment.py
+++ b/packages/python/algokit_transact/tests/test_payment.py
@@ -11,8 +11,13 @@ from algokit_transact import (
     Transaction,
     address_from_string,
     address_from_pub_key,
+    get_transaction_id,
+    get_transaction_raw_id
 )
 from nacl.signing import SigningKey
+import base64
+
+transaction: Transaction = TEST_DATA["transaction"]
 
 # Polytest Suite: Payment
 
@@ -88,4 +93,16 @@ def test_encode():
         encode_transaction(TEST_DATA["transaction"])
         == TEST_DATA["expected_bytes_for_signing"]
     )
+
+
+@pytest.mark.group_transaction_tests
+def test_get_transaction_id():
+    """A transaction id can be obtained from a transaction"""
+
+    assert(get_transaction_raw_id(transaction) == bytes([
+          89, 237, 187, 95, 72, 48, 184, 21, 54, 185, 237, 245, 160, 212, 160,
+          212, 214, 207, 239, 131, 123, 133, 183, 247, 179, 37, 169, 90, 79, 19,
+          170, 171,
+        ]))
+    assert(get_transaction_id(transaction) == "LHW3WX2IGC4BKNVZ5X22BVFA2TLM734DPOC3P55TEWUVUTYTVKVQ")
 

--- a/packages/typescript/algokit_transact/__tests__/payment.test.ts
+++ b/packages/typescript/algokit_transact/__tests__/payment.test.ts
@@ -9,6 +9,8 @@ import {
   Transaction,
   addressFromPubKey,
   addressFromString,
+  getTransactionRawId,
+  getTransactionId,
 } from "../src/index";
 
 const transaction: Transaction = testData.transaction;
@@ -24,7 +26,7 @@ describe("Payment", () => {
 
     test("decode without prefix", () => {
       expect(decodeTransaction(expectedBytesForSigning.slice(2))).toEqual(
-        transaction,
+        transaction
       );
     });
 
@@ -38,7 +40,7 @@ describe("Payment", () => {
       const alice = addressFromPubKey(alicePubKey);
 
       const bob = addressFromString(
-        "B72WNFFEZ7EOGMQPP7ROHYS3DSLL5JW74QASYNWGZGQXWRPJECJJLJIJ2Y",
+        "B72WNFFEZ7EOGMQPP7ROHYS3DSLL5JW74QASYNWGZGQXWRPJECJJLJIJ2Y"
       );
 
       const txn: Transaction = {
@@ -63,7 +65,7 @@ describe("Payment", () => {
 
     test("get encoded transaction type", () => {
       expect(getEncodedTransactionType(expectedBytesForSigning)).toBe(
-        "Payment",
+        "Payment"
       );
     });
 
@@ -75,6 +77,19 @@ describe("Payment", () => {
 
     test("encode", () => {
       expect(encodeTransaction(transaction)).toEqual(expectedBytesForSigning);
+    });
+
+    test("get transaction id", () => {
+      expect(getTransactionRawId(transaction)).toEqual(
+        Uint8Array.from([
+          89, 237, 187, 95, 72, 48, 184, 21, 54, 185, 237, 245, 160, 212, 160,
+          212, 214, 207, 239, 131, 123, 133, 183, 247, 179, 37, 169, 90, 79, 19,
+          170, 171,
+        ])
+      );
+      expect(getTransactionId(transaction)).toEqual(
+        "LHW3WX2IGC4BKNVZ5X22BVFA2TLM734DPOC3P55TEWUVUTYTVKVQ"
+      );
     });
   });
 });


### PR DESCRIPTION
I'm using the test transaction data that is included in the json file, however I think it makes sense to share the test data we'll expose in the object mother / test data factory.