### PR TITLE
Update the template to expose the response context

### DIFF
--- a/api/oas_templates/typescript/api/api.mustache
+++ b/api/oas_templates/typescript/api/api.mustache
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi{{importFileExtension}}';
 import {Configuration} from '../configuration{{importFileExtension}}';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http{{importFileExtension}}';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http{{importFileExtension}}';
 {{#platforms}}
 {{#node}}
 import {{^supportsES6}}* as{{/supportsES6}} FormData from "form-data";
@@ -210,7 +210,7 @@ export class {{classname}}ResponseProcessor {
      * @params response Response returned by the server for a request to {{nickname}}
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async {{nickname}}WithHttpInfo(response: ResponseContext): Promise<HttpInfo<{{{returnType}}} {{^returnType}}void{{/returnType}}>> {
+     public async {{nickname}}Response(response: ResponseContext): Promise<{{{returnType}}} {{^returnType}}void{{/returnType}}> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         {{#responses}}
         if (isCodeInRange("{{code}}", response.httpStatusCode)) {
@@ -225,7 +225,7 @@ export class {{classname}}ResponseProcessor {
             ) as {{{dataType}}};
             {{/isBinary}}
             {{#is2xx}}
-            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
+            return body;
             {{/is2xx}}
             {{^is2xx}}
             throw new ApiException<{{{dataType}}}>(response.httpStatusCode, "{{message}}", body, response.headers);
@@ -233,7 +233,7 @@ export class {{classname}}ResponseProcessor {
             {{/dataType}}
             {{^dataType}}
             {{#is2xx}}
-            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
+            return undefined;
             {{/is2xx}}
             {{^is2xx}}
             throw new ApiException<undefined>(response.httpStatusCode, "{{message}}", undefined, response.headers);
@@ -254,10 +254,10 @@ export class {{classname}}ResponseProcessor {
                 "{{{returnType}}}", "{{returnFormat}}"
             ) as {{{returnType}}};
             {{/isBinary}}
-            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
+            return body;
             {{/returnType}}
             {{^returnType}}
-            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
+            return undefined;
             {{/returnType}}
         }
 

--- a/api/oas_templates/typescript/http/http.mustache
+++ b/api/oas_templates/typescript/http/http.mustache
@@ -226,6 +226,7 @@ export class SelfDecodingBody implements ResponseBody {
 export class ResponseContext {
     public constructor(
         public httpStatusCode: number,
+        public httpStatusText: string,
         public headers: Headers,
         public body: ResponseBody
     ) {}
@@ -316,15 +317,4 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
       return from(promiseHttpLibrary.send(request));
     }
   }
-}
-
-export class HttpInfo<T> extends ResponseContext {
-    public constructor(
-        httpStatusCode: number,
-        headers: Headers,
-        body: ResponseBody,
-        public data: T,
-    ) {
-        super(httpStatusCode, headers, body);
-    }
 }

--- a/api/oas_templates/typescript/http/isomorphic-fetch.mustache
+++ b/api/oas_templates/typescript/http/isomorphic-fetch.mustache
@@ -47,7 +47,7 @@ export class IsomorphicFetchHttpLibrary implements HttpLibrary {
             };
             {{/node}}
             {{/platforms}}
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(resp.status, resp.statusText, headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/api/oas_templates/typescript/types/ObjectParamAPI.mustache
+++ b/api/oas_templates/typescript/types/ObjectParamAPI.mustache
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http{{importFileExtension}}';
+import { ResponseContext, RequestContext, HttpFile } from '../http/http{{importFileExtension}}';
 import { Configuration{{^useInversify}}, ConfigurationOptions{{/useInversify}} } from '../configuration{{importFileExtension}}'
 {{^useInversify}}
 import type { Middleware } from '../middleware{{importFileExtension}}';
@@ -58,8 +58,8 @@ export class Object{{classname}} {
      {{/summary}}
      * @param param the request object
      */
-    public {{nickname}}WithHttpInfo(param: {{classname}}{{operationIdCamelCase}}Request{{^hasRequiredParams}} = {}{{/hasRequiredParams}}, options?: Configuration{{^useInversify}}Options{{/useInversify}}): {{#useRxJS}}Observable{{/useRxJS}}{{^useRxJS}}Promise{{/useRxJS}}<HttpInfo<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
-        return this.api.{{nickname}}WithHttpInfo({{#allParams}}param.{{paramName}}, {{/allParams}} options){{^useRxJS}}.toPromise(){{/useRxJS}};
+    public {{nickname}}Response(param: {{classname}}{{operationIdCamelCase}}Request{{^hasRequiredParams}} = {}{{/hasRequiredParams}}, options?: Configuration{{^useInversify}}Options{{/useInversify}}): {{#useRxJS}}Observable{{/useRxJS}}{{^useRxJS}}Promise{{/useRxJS}}<ResponseContext> {
+        return this.api.{{nickname}}Response({{#allParams}}param.{{paramName}}, {{/allParams}} options){{^useRxJS}}.toPromise(){{/useRxJS}};
     }
 
     /**

--- a/api/oas_templates/typescript/types/ObservableAPI.mustache
+++ b/api/oas_templates/typescript/types/ObservableAPI.mustache
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http{{importFileExtension}}';
+import { ResponseContext, RequestContext, HttpFile } from '../http/http{{importFileExtension}}';
 import { Configuration{{^useInversify}}, ConfigurationOptions{{/useInversify}} } from '../configuration{{importFileExtension}}'
 import type { Middleware } from '../middleware{{importFileExtension}}';
 import { Observable, of, from } from {{#useRxJS}}'rxjs'{{/useRxJS}}{{^useRxJS}}'../rxjsStub{{importFileExtension}}'{{/useRxJS}};
@@ -62,7 +62,7 @@ export class Observable{{classname}} {
      * @param {{#required}}{{paramName}}{{/required}}{{^required}}[{{paramName}}]{{/required}}{{#description}} {{description}}{{/description}}
      {{/allParams}}
      */
-    public {{nickname}}WithHttpInfo({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration{{^useInversify}}Options{{/useInversify}}): Observable<HttpInfo<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
+    public {{nickname}}Response({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration{{^useInversify}}Options{{/useInversify}}): Observable<ResponseContext> {
     let _config = this.configuration;
     let allMiddleware: Middleware[] = [];
     {{#useInversify}}
@@ -114,7 +114,7 @@ export class Observable{{classname}} {
                 for (const middleware of allMiddleware.reverse()) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.{{nickname}}WithHttpInfo(rsp)));
+                return middlewarePostObservable;
             }));
     }
 
@@ -130,7 +130,8 @@ export class Observable{{classname}} {
      {{/allParams}}
      */
     public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration{{^useInversify}}Options{{/useInversify}}): Observable<{{{returnType}}}{{^returnType}}void{{/returnType}}> {
-        return this.{{nickname}}WithHttpInfo({{#allParams}}{{paramName}}, {{/allParams}}_options).pipe(map((apiResponse: HttpInfo<{{{returnType}}}{{^returnType}}void{{/returnType}}>) => apiResponse.data));
+        return this.{{nickname}}Response({{#allParams}}{{paramName}}, {{/allParams}}_options)
+          .pipe(map((rsp: ResponseContext) => this.responseProcessor.{{nickname}}Response(rsp)));
     }
 
 {{/operation}}

--- a/api/oas_templates/typescript/types/PromiseAPI.mustache
+++ b/api/oas_templates/typescript/types/PromiseAPI.mustache
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http{{importFileExtension}}';
+import { ResponseContext, RequestContext, HttpFile } from '../http/http{{importFileExtension}}';
 import { Configuration{{^useInversify}}, ConfigurationOptions, PromiseConfigurationOptions{{/useInversify}} } from '../configuration{{importFileExtension}}'
 {{^useInversify}}
 import { PromiseMiddleware, Middleware, PromiseMiddlewareWrapper } from '../middleware{{importFileExtension}}';
@@ -54,7 +54,7 @@ export class Promise{{classname}} {
      * @param {{#required}}{{paramName}}{{/required}}{{^required}}[{{paramName}}]{{/required}}{{#description}} {{description}}{{/description}}
      {{/allParams}}
      */
-    public {{nickname}}WithHttpInfo({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: {{#useInversify}}Configuration{{/useInversify}}{{^useInversify}}PromiseConfigurationOptions{{/useInversify}}): Promise<HttpInfo<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
+    public {{nickname}}Response({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: {{#useInversify}}Configuration{{/useInversify}}{{^useInversify}}PromiseConfigurationOptions{{/useInversify}}): Promise<ResponseContext> {
         let observableOptions: undefined | Configuration{{^useInversify}}Options{{/useInversify}}{{#useInversify}} = _options{{/useInversify}}
         {{^useInversify}}
         if (_options){
@@ -69,7 +69,7 @@ export class Promise{{classname}} {
 	    }
 	}
         {{/useInversify}}
-        const result = this.api.{{nickname}}WithHttpInfo({{#allParams}}{{paramName}}, {{/allParams}}observableOptions);
+        const result = this.api.{{nickname}}Response({{#allParams}}{{paramName}}, {{/allParams}}observableOptions);
         return result.toPromise();
     }
 


### PR DESCRIPTION
Update the template to expose the response context:
- Add http status text to response context
- Instead of using HttpInfo class, expose the response context directly.
The reason for this change is that in utils-ts, I found that I need access to the raw binary returned from the http call. Currently, there are methods such as `rawTransactionWithHttpInfo`  that return the `HttpInfo` (wrapper of the `ResponseContext`), there are some limitations:
- when processing the response, if the response type isn't binary, the text is extracted from the response. This makes the binary stream unusable downstream. In utils-ts, I can't read the binary anymore.
- `HttpInfo` is just a thin wrapper around `ResponseContext`, I think we should just expose the `ResponseContext` and the consumers have full control of how they want to use it.