### PR TITLE
ci: add typescript & fix semantic-release failure

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -14,18 +14,33 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       # The packages that use Uniffi bindings
-      uniffi_packages: ${{ steps.set_uniffi_packages.outputs.uniffi_packages }}
+      ffi_packages: ${{ steps.set_ffi_packages.outputs.ffi_packages }}
     steps:
-      - id: set_uniffi_packages
-        run: echo 'uniffi_packages=["algokit_transact"]' >> $GITHUB_OUTPUT
+      - id: set_ffi_packages
+        run: echo 'ffi_packages=["algokit_transact"]' >> $GITHUB_OUTPUT
 
 
+  typescript_wasm_ci_cd:
+    concurrency: ${{ github.event_name == 'push' && format('cd-{0}', github.ref) || format('ci-typescript_wasm-{0}', github.run_id) }}
+    needs: setup
+    uses: ./.github/workflows/typescript_wasm_ci_cd.yml
+    strategy:
+      matrix:
+        crate: ${{ fromJSON(needs.setup.outputs.ffi_packages) }}
+    with:
+      crate: ${{ matrix.crate }}
+      release: ${{ github.event_name == 'push' }}
+    secrets:
+      BOT_ID: ${{ secrets.BOT_ID }}
+      BOT_SK: ${{ secrets.BOT_SK }}
+  
   python_uniffi_ci_cd:
+    concurrency: ${{ github.event_name == 'push' && format('cd-{0}', github.ref) || format('ci-python_uniffi-{0}', github.run_id) }}
     needs: setup
     uses: ./.github/workflows/python_uniffi_ci_cd.yml
     strategy:
       matrix:
-        crate: ${{ fromJSON(needs.setup.outputs.uniffi_packages) }}
+        crate: ${{ fromJSON(needs.setup.outputs.ffi_packages) }}
     with:
       crate: ${{ matrix.crate }}
       release: ${{ github.event_name == 'push' }}

--- a/.github/workflows/python_uniffi_ci_cd.yml
+++ b/.github/workflows/python_uniffi_ci_cd.yml
@@ -47,6 +47,8 @@ jobs:
           app-id: ${{ secrets.BOT_ID }}
           private-key: ${{ secrets.BOT_SK }}
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
         if: inputs.release
       - uses: oven-sh/setup-bun@v2
         if: inputs.release
@@ -259,6 +261,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
+          merge-multiple: true
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/typescript_wasm_ci_cd.yml
+++ b/.github/workflows/typescript_wasm_ci_cd.yml
@@ -1,0 +1,58 @@
+name: TypeScript CI
+
+on:
+  workflow_call:
+    inputs:
+      crate:
+        required: true
+        type: string
+        description: "The name of the crate to build and publish"
+      release:
+        required: false
+        type: boolean
+        default: false
+        description: "Whether to run release steps"
+    secrets:
+      BOT_ID:
+        required: true
+      BOT_SK:
+        required: true
+
+permissions:
+  contents: write # to make commits
+  actions: write # to upload artifacts
+  issues: write # to be able to comment on released issues
+  pull-requests: write # to be able to comment on released pull requests
+
+jobs:
+  build_and_test:
+    defaults:
+      run:
+        shell: bash
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v1
+        if: inputs.release
+        id: app_token
+        with:
+          app-id: ${{ secrets.BOT_ID }}
+          private-key: ${{ secrets.BOT_SK }}
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.85.0
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile 
+      - name: Build
+        run: bun scripts/build ${{ inputs.CRATE }} typescript
+      - name: Test
+        run: cd packages/typescript/${{ inputs.CRATE }} && bun test
+      - name: Release
+        if: inputs.release
+        env:
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: bun release:${{ inputs.CRATE }}:ts

--- a/packages/python/algokit_transact/release.config.cjs
+++ b/packages/python/algokit_transact/release.config.cjs
@@ -3,5 +3,5 @@ const releaseUtils = require("../../../utils/semantic-release.cjs");
 module.exports = releaseUtils.getConfig({
   language: "python",
   package_name: "algokit_transact",
-  assets: ["../../../artifacts/*-wheel/**/*"],
+  assets: ["../../../artifacts/*.whl"],
 });

--- a/packages/typescript/algokit_transact/release.config.cjs
+++ b/packages/typescript/algokit_transact/release.config.cjs
@@ -1,0 +1,13 @@
+const releaseUtils = require("../../../utils/semantic-release.cjs");
+
+const config = releaseUtils.getConfig({
+  language: "typescript",
+  package_name: "algokit_transact",
+});
+
+config.plugins = [
+  ...config.plugins,
+  ["@semantic-release/npm", { npmPublish: false }],
+];
+
+module.exports = config;

--- a/utils/semantic-release.cjs
+++ b/utils/semantic-release.cjs
@@ -12,7 +12,7 @@ module.exports = {
     const { language, package_name } = opts;
     const assets = opts.assets || [];
     return {
-      branches: [{ name: "main", prerelease: "alpha" }],
+      branches: ["release", { name: "main", prerelease: "alpha" }],
       repositoryUrl: "https://github.com/algorandfoundation/algokit-core",
       tagFormat: `${language}/${package_name}` + "@${version}",
       plugins: [


### PR DESCRIPTION
This PR adds CI/CD for TypeScript via `semantic-release` for publishing to GitHub. NPM publish will come in a later PR. 

Also includes a small non-functional change to Python CI to merge artifacts, which will be useful for publishing to PyPi in a later PR

Test workflow here: https://github.com/joe-p/algokit-core/actions/runs/14794339009

Edit: Also included a fix for https://github.com/algorandfoundation/algokit-core/actions/runs/14757838024/job/41430646761