### PR TITLE
feat: Remove transaction type from the transaction header struct

### DIFF
--- a/crates/algokit_transact/src/lib.rs
+++ b/crates/algokit_transact/src/lib.rs
@@ -16,7 +16,7 @@ pub use traits::{AlgorandMsgpack, TransactionId};
 pub use transactions::{
     AssetTransferTransactionBuilder, AssetTransferTransactionFields, PaymentTransactionBuilder,
     PaymentTransactionFields, SignedTransaction, Transaction, TransactionHeader,
-    TransactionHeaderBuilder, TransactionType,
+    TransactionHeaderBuilder,
 };
 
 #[cfg(test)]

--- a/crates/algokit_transact/src/test_utils/mod.rs
+++ b/crates/algokit_transact/src/test_utils/mod.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use crate::{
     transactions::{AssetTransferTransactionBuilder, PaymentTransactionBuilder},
     Address, AlgorandMsgpack, Byte32, SignedTransaction, Transaction, TransactionHeaderBuilder,
-    TransactionId, TransactionType,
+    TransactionId,
 };
 use base64::{prelude::BASE64_STANDARD, Engine};
 use convert_case::{Case, Casing};
@@ -23,6 +23,7 @@ impl TransactionHeaderMother {
                     .try_into()
                     .unwrap(),
             )
+            .fee(1000)
             .to_owned()
     }
 
@@ -36,29 +37,15 @@ impl TransactionHeaderMother {
                     .try_into()
                     .unwrap(),
             )
+            .fee(1000)
             .to_owned()
     }
 
-    pub fn simple_testnet_payment() -> TransactionHeaderBuilder {
+    pub fn simple_testnet() -> TransactionHeaderBuilder {
         Self::testnet()
-            .transaction_type(TransactionType::Payment)
             .sender(AddressMother::address())
-            .fee(1000)
             .first_valid(50659540)
             .last_valid(50660540)
-            .to_owned()
-    }
-
-    pub fn simple_testnet_asset_transfer() -> TransactionHeaderBuilder {
-        Self::testnet()
-            .transaction_type(TransactionType::AssetTransfer)
-            .sender(
-                Address::from_string("JB3K6HTAXODO4THESLNYTSG6GQUFNEVIQG7A6ZYVDACR6WA3ZF52TKU5NA")
-                    .unwrap(),
-            )
-            .fee(1000)
-            .first_valid(51183672)
-            .last_valid(51183872)
             .to_owned()
     }
 }
@@ -67,11 +54,7 @@ pub struct TransactionMother {}
 impl TransactionMother {
     pub fn simple_payment() -> PaymentTransactionBuilder {
         PaymentTransactionBuilder::default()
-            .header(
-                TransactionHeaderMother::simple_testnet_payment()
-                    .build()
-                    .unwrap(),
-            )
+            .header(TransactionHeaderMother::simple_testnet().build().unwrap())
             .amount(101000)
             .receiver(
                 Address::from_string("VXH5UP6JLU2CGIYPUFZ4Z5OTLJCLMA5EXD3YHTMVNDE5P7ILZ324FSYSPQ")
@@ -83,7 +66,7 @@ impl TransactionMother {
     pub fn payment_with_note() -> PaymentTransactionBuilder {
         Self::simple_payment()
             .header(
-                TransactionHeaderMother::simple_testnet_payment()
+                TransactionHeaderMother::simple_testnet()
                     .note(
                         BASE64_STANDARD
                             .decode("MGFhNTBkMjctYjhmNy00ZDc3LWExZmItNTUxZmQ1NWRmMmJj")
@@ -99,7 +82,15 @@ impl TransactionMother {
     pub fn opt_in_asset_transfer() -> AssetTransferTransactionBuilder {
         AssetTransferTransactionBuilder::default()
             .header(
-                TransactionHeaderMother::simple_testnet_asset_transfer()
+                TransactionHeaderMother::simple_testnet()
+                    .sender(
+                        Address::from_string(
+                            "JB3K6HTAXODO4THESLNYTSG6GQUFNEVIQG7A6ZYVDACR6WA3ZF52TKU5NA",
+                        )
+                        .unwrap(),
+                    )
+                    .first_valid(51183672)
+                    .last_valid(51183872)
                     .build()
                     .unwrap(),
             )

--- a/crates/algokit_transact/src/tests.rs
+++ b/crates/algokit_transact/src/tests.rs
@@ -1,7 +1,6 @@
 use crate::{
     test_utils::{AddressMother, TransactionMother},
-    Address, AlgorandMsgpack, AssetTransferTransactionFields, PaymentTransactionFields,
-    SignedTransaction, Transaction, TransactionId,
+    Address, AlgorandMsgpack, SignedTransaction, Transaction, TransactionId,
 };
 use pretty_assertions::assert_eq;
 
@@ -11,17 +10,10 @@ fn test_payment_transaction_encoding() {
     let payment_tx_fields = tx_builder.build_fields().unwrap();
     let payment_tx = tx_builder.build().unwrap();
 
-    let encoded_struct = payment_tx_fields.encode().unwrap();
-    let decoded_struct = PaymentTransactionFields::decode(&encoded_struct).unwrap();
-    assert_eq!(decoded_struct, payment_tx_fields);
-
-    let encoded_enum = payment_tx.encode().unwrap();
-    let decoded_enum = Transaction::decode(&encoded_enum).unwrap();
-    assert_eq!(decoded_enum, payment_tx);
-    assert_eq!(
-        decoded_enum,
-        Transaction::Payment(payment_tx_fields.clone())
-    );
+    let encoded = payment_tx.encode().unwrap();
+    let decoded = Transaction::decode(&encoded).unwrap();
+    assert_eq!(decoded, payment_tx);
+    assert_eq!(decoded, Transaction::Payment(payment_tx_fields));
 
     let signed_tx = SignedTransaction {
         transaction: payment_tx.clone(),
@@ -32,12 +24,12 @@ fn test_payment_transaction_encoding() {
     assert_eq!(decoded_stx, signed_tx);
     assert_eq!(decoded_stx.transaction, payment_tx);
 
-    let raw_encoding = payment_tx_fields.encode_raw().unwrap();
-    assert_eq!(encoded_struct[0], b'T');
-    assert_eq!(encoded_struct[1], b'X');
-    assert_eq!(encoded_struct.len(), raw_encoding.len() + 2);
-    assert_eq!(encoded_struct[2..], raw_encoding);
-    assert_eq!(encoded_struct.len(), 174);
+    let raw_encoded = payment_tx.encode_raw().unwrap();
+    assert_eq!(encoded[0], b'T');
+    assert_eq!(encoded[1], b'X');
+    assert_eq!(encoded.len(), raw_encoded.len() + 2);
+    assert_eq!(encoded[2..], raw_encoded);
+    assert_eq!(encoded.len(), 174);
 }
 
 #[test]
@@ -46,13 +38,13 @@ fn test_asset_transfer_transaction_encoding() {
     let asset_transfer_tx_fields = tx_builder.build_fields().unwrap();
     let asset_transfer_tx = tx_builder.build().unwrap();
 
-    let encoded_struct = asset_transfer_tx_fields.encode().unwrap();
-    let decoded_struct = AssetTransferTransactionFields::decode(&encoded_struct).unwrap();
-    assert_eq!(decoded_struct, asset_transfer_tx_fields);
-
-    let encoded_enum = asset_transfer_tx.encode().unwrap();
-    let decoded_enum = Transaction::decode(&encoded_enum).unwrap();
-    assert_eq!(decoded_enum, asset_transfer_tx);
+    let encoded = asset_transfer_tx.encode().unwrap();
+    let decoded = Transaction::decode(&encoded).unwrap();
+    assert_eq!(decoded, asset_transfer_tx);
+    assert_eq!(
+        decoded,
+        Transaction::AssetTransfer(asset_transfer_tx_fields)
+    );
 
     let signed_tx = SignedTransaction {
         transaction: asset_transfer_tx.clone(),
@@ -63,12 +55,12 @@ fn test_asset_transfer_transaction_encoding() {
     assert_eq!(decoded_stx, signed_tx);
     assert_eq!(decoded_stx.transaction, asset_transfer_tx);
 
-    let raw_encoding = asset_transfer_tx_fields.encode_raw().unwrap();
-    assert_eq!(encoded_struct[0], b'T');
-    assert_eq!(encoded_struct[1], b'X');
-    assert_eq!(encoded_struct.len(), raw_encoding.len() + 2);
-    assert_eq!(encoded_struct[2..], raw_encoding);
-    assert_eq!(encoded_struct.len(), 178);
+    let raw_encoded = asset_transfer_tx.encode_raw().unwrap();
+    assert_eq!(encoded[0], b'T');
+    assert_eq!(encoded[1], b'X');
+    assert_eq!(encoded.len(), raw_encoded.len() + 2);
+    assert_eq!(encoded[2..], raw_encoded);
+    assert_eq!(encoded.len(), 178);
 }
 
 #[test]
@@ -103,14 +95,12 @@ fn test_pay_transaction_raw_id() {
     ];
 
     let tx_builder = TransactionMother::payment_with_note();
-    let payment_tx_fields = tx_builder.build_fields().unwrap();
     let payment_tx = tx_builder.build().unwrap();
     let signed_tx = SignedTransaction {
         transaction: payment_tx.clone(),
         signature: [0; 64],
     };
 
-    assert_eq!(payment_tx_fields.raw_id().unwrap(), expected_tx_id);
     assert_eq!(payment_tx.raw_id().unwrap(), expected_tx_id);
     assert_eq!(signed_tx.raw_id().unwrap(), expected_tx_id);
 }
@@ -120,14 +110,12 @@ fn test_pay_transaction_id() {
     let expected_tx_id = "ENOQBKTA3UAUU54TQN2AOH7BFDLS6LDYQD2SSQLU76JUAWSQSPPQ";
 
     let tx_builder = TransactionMother::payment_with_note();
-    let payment_tx_fields = tx_builder.build_fields().unwrap();
     let payment_tx = tx_builder.build().unwrap();
     let signed_tx = SignedTransaction {
         transaction: payment_tx.clone(),
         signature: [0; 64],
     };
 
-    assert_eq!(payment_tx_fields.id().unwrap(), expected_tx_id);
     assert_eq!(payment_tx.id().unwrap(), expected_tx_id);
     assert_eq!(signed_tx.id().unwrap(), expected_tx_id);
 }

--- a/crates/algokit_transact/src/transactions/asset_transfer.rs
+++ b/crates/algokit_transact/src/transactions/asset_transfer.rs
@@ -1,5 +1,4 @@
 use crate::address::Address;
-use crate::traits::{AlgorandMsgpack, TransactionId};
 use crate::transactions::common::TransactionHeader;
 use crate::utils::{is_zero, is_zero_addr, is_zero_addr_opt};
 use derive_builder::Builder;
@@ -45,6 +44,3 @@ pub struct AssetTransferTransactionFields {
     #[builder(default)]
     pub close_remainder_to: Option<Address>,
 }
-
-impl AlgorandMsgpack for AssetTransferTransactionFields {}
-impl TransactionId for AssetTransferTransactionFields {}

--- a/crates/algokit_transact/src/transactions/common.rs
+++ b/crates/algokit_transact/src/transactions/common.rs
@@ -1,6 +1,5 @@
 use crate::address::Address;
 use crate::constants::Byte32;
-use crate::traits::AlgorandMsgpack;
 use crate::utils::{
     is_empty_bytes32_opt, is_empty_string_opt, is_empty_vec_opt, is_zero, is_zero_addr,
     is_zero_addr_opt,
@@ -9,35 +8,11 @@ use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, skip_serializing_none, Bytes};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub enum TransactionType {
-    #[serde(rename = "pay")]
-    Payment,
-
-    #[serde(rename = "axfer")]
-    AssetTransfer,
-
-    #[serde(rename = "afrz")]
-    AssetFreeze,
-
-    #[serde(rename = "acfg")]
-    AssetConfig,
-
-    #[serde(rename = "keyreg")]
-    KeyRegistration,
-
-    #[serde(rename = "appl")]
-    ApplicationCall,
-}
-
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Builder)]
 #[builder(setter(strip_option))]
 pub struct TransactionHeader {
-    #[serde(rename = "type")]
-    pub transaction_type: TransactionType,
-
     #[serde(rename = "snd")]
     #[serde(skip_serializing_if = "is_zero_addr")]
     #[serde(default)]
@@ -96,5 +71,3 @@ pub struct TransactionHeader {
     #[builder(default)]
     pub group: Option<Byte32>,
 }
-
-impl AlgorandMsgpack for TransactionHeader {}

--- a/crates/algokit_transact/src/transactions/mod.rs
+++ b/crates/algokit_transact/src/transactions/mod.rs
@@ -4,7 +4,7 @@ mod payment;
 
 use asset_transfer::AssetTransferTransactionBuilderError;
 pub use asset_transfer::{AssetTransferTransactionBuilder, AssetTransferTransactionFields};
-pub use common::{TransactionHeader, TransactionHeaderBuilder, TransactionType};
+pub use common::{TransactionHeader, TransactionHeaderBuilder};
 use payment::PaymentTransactionBuilderError;
 pub use payment::{PaymentTransactionBuilder, PaymentTransactionFields};
 
@@ -16,49 +16,40 @@ use serde_with::{serde_as, Bytes};
 use std::any::Any;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-#[serde(untagged)]
+#[serde(tag = "type")]
 pub enum Transaction {
+    #[serde(rename = "pay")]
     Payment(PaymentTransactionFields),
+
+    #[serde(rename = "axfer")]
     AssetTransfer(AssetTransferTransactionFields),
+    // All the below transaction variants will be implemented in the future
+    // #[serde(rename = "afrz")]
+    // AssetFreeze(...),
+
+    // #[serde(rename = "acfg")]
+    // AssetConfig(...),
+
+    // #[serde(rename = "keyreg")]
+    // KeyRegistration(...),
+
+    // #[serde(rename = "appl")]
+    // ApplicationCall(...),
 }
 
 impl PaymentTransactionBuilder {
     pub fn build(&self) -> Result<Transaction, PaymentTransactionBuilderError> {
-        self.build_fields().map(|t| Transaction::Payment(t))
+        self.build_fields().map(|d| Transaction::Payment(d))
     }
 }
 
 impl AssetTransferTransactionBuilder {
     pub fn build(&self) -> Result<Transaction, AssetTransferTransactionBuilderError> {
-        self.build_fields().map(|t| Transaction::AssetTransfer(t))
+        self.build_fields().map(|d| Transaction::AssetTransfer(d))
     }
 }
 
-impl AlgorandMsgpack for Transaction {
-    fn encode(&self) -> Result<Vec<u8>, AlgoKitTransactError> {
-        match self {
-            Transaction::Payment(tx) => tx.encode(),
-            Transaction::AssetTransfer(tx) => tx.encode(),
-        }
-    }
-
-    fn decode(bytes: &[u8]) -> Result<Self, AlgoKitTransactError> {
-        let header = TransactionHeader::decode(bytes)?;
-
-        match header.transaction_type {
-            TransactionType::Payment => Ok(Transaction::Payment(PaymentTransactionFields::decode(
-                bytes,
-            )?)),
-            TransactionType::AssetTransfer => Ok(Transaction::AssetTransfer(
-                AssetTransferTransactionFields::decode(bytes)?,
-            )),
-            _ => Err(AlgoKitTransactError::UnknownTransactionType(format!(
-                "{:?}",
-                header.transaction_type
-            ))),
-        }
-    }
-}
+impl AlgorandMsgpack for Transaction {}
 impl TransactionId for Transaction {}
 
 #[serde_as]

--- a/crates/algokit_transact/src/transactions/payment.rs
+++ b/crates/algokit_transact/src/transactions/payment.rs
@@ -1,5 +1,4 @@
 use crate::address::Address;
-use crate::traits::{AlgorandMsgpack, TransactionId};
 use crate::transactions::common::TransactionHeader;
 use crate::utils::{is_zero, is_zero_addr, is_zero_addr_opt};
 use derive_builder::Builder;
@@ -34,6 +33,3 @@ pub struct PaymentTransactionFields {
     #[builder(default)]
     pub close_remainder_to: Option<Address>,
 }
-
-impl AlgorandMsgpack for PaymentTransactionFields {}
-impl TransactionId for PaymentTransactionFields {}


### PR DESCRIPTION
When adding the builders and object mothers I noticed that when creating a transaction it felt a little redundant assigning a specific transaction type inside a transaction header, given that it's nested within the `*TransactionFields` struct and then also wrapped in an enum variant which both specify the transaction type. Additionally it was possible to create a transaction with a mismatched transaction type.

This PR removes the TransactionType enum and leverages the serde enum tag feature. The FFI trait definitions have not changed.