### PR TITLE
chore: update config for python projects to support vscode better

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,7 @@
     "tamasfe.even-better-toml",
     "editorconfig.editorconfig",
     "matangover.mypy",
-    "rust-lang.rust-analyzer"
+    "rust-lang.rust-analyzer",
+    "teticio.python-envy"
   ]
 }

--- a/packages/python/algokit_transact/poetry.toml
+++ b/packages/python/algokit_transact/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+in-project = true


### PR DESCRIPTION
The VSCode mypy plugin doesn't work very well with mono repos.
This change adds a recommended plugin which automatically selects the relevant venv when navigating through different projects in a monorepo.