### PR TITLE
feat: estimate transaction size in the FFI crate

### DIFF
--- a/crates/algokit_transact/src/constants.rs
+++ b/crates/algokit_transact/src/constants.rs
@@ -2,4 +2,5 @@ pub const HASH_BYTES_LENGTH: usize = 32;
 pub const ALGORAND_CHECKSUM_BYTE_LENGTH: usize = 4;
 pub const ALGORAND_ADDRESS_LENGTH: usize = 58;
 pub const ALGORAND_PUBLIC_KEY_BYTE_LENGTH: usize = 32;
+pub const ALGORAND_SIGNATURE_ENCODING_INCR: usize = 75;
 pub type Byte32 = [u8; 32];

--- a/crates/algokit_transact/src/lib.rs
+++ b/crates/algokit_transact/src/lib.rs
@@ -12,7 +12,7 @@ pub use constants::{
     ALGORAND_PUBLIC_KEY_BYTE_LENGTH, HASH_BYTES_LENGTH,
 };
 pub use error::AlgoKitTransactError;
-pub use traits::{AlgorandMsgpack, TransactionId};
+pub use traits::{AlgorandMsgpack, EstimateTransactionSize, TransactionId};
 pub use transactions::{
     AssetTransferTransactionBuilder, AssetTransferTransactionFields, PaymentTransactionBuilder,
     PaymentTransactionFields, SignedTransaction, Transaction, TransactionHeader,

--- a/crates/algokit_transact/src/test_utils/mod.rs
+++ b/crates/algokit_transact/src/test_utils/mod.rs
@@ -1,4 +1,3 @@
-use std::fs::File;
 use crate::{
     transactions::{AssetTransferTransactionBuilder, PaymentTransactionBuilder},
     Address, AlgorandMsgpack, Byte32, SignedTransaction, Transaction, TransactionHeaderBuilder,
@@ -9,6 +8,7 @@ use convert_case::{Case, Casing};
 use ed25519_dalek::{Signer, SigningKey};
 use serde::Serialize;
 use serde_json::to_writer_pretty;
+use std::fs::File;
 
 pub struct TransactionHeaderMother {}
 impl TransactionHeaderMother {
@@ -56,8 +56,9 @@ impl TransactionMother {
             .header(TransactionHeaderMother::simple_testnet().build().unwrap())
             .amount(101000)
             .receiver(
-                "VXH5UP6JLU2CGIYPUFZ4Z5OTLJCLMA5EXD3YHTMVNDE5P7ILZ324FSYSPQ".parse::<Address>()
-                    .unwrap()
+                "VXH5UP6JLU2CGIYPUFZ4Z5OTLJCLMA5EXD3YHTMVNDE5P7ILZ324FSYSPQ"
+                    .parse::<Address>()
+                    .unwrap(),
             )
             .to_owned()
     }
@@ -83,8 +84,9 @@ impl TransactionMother {
             .header(
                 TransactionHeaderMother::simple_testnet()
                     .sender(
-                        "JB3K6HTAXODO4THESLNYTSG6GQUFNEVIQG7A6ZYVDACR6WA3ZF52TKU5NA".parse::<Address>()
-                            .unwrap()
+                        "JB3K6HTAXODO4THESLNYTSG6GQUFNEVIQG7A6ZYVDACR6WA3ZF52TKU5NA"
+                            .parse::<Address>()
+                            .unwrap(),
                     )
                     .first_valid(51183672)
                     .last_valid(51183872)
@@ -94,8 +96,9 @@ impl TransactionMother {
             .asset_id(107686045)
             .amount(0)
             .receiver(
-                "JB3K6HTAXODO4THESLNYTSG6GQUFNEVIQG7A6ZYVDACR6WA3ZF52TKU5NA".parse::<Address>()
-                    .unwrap()
+                "JB3K6HTAXODO4THESLNYTSG6GQUFNEVIQG7A6ZYVDACR6WA3ZF52TKU5NA"
+                    .parse::<Address>()
+                    .unwrap(),
             )
             .to_owned()
     }
@@ -108,7 +111,8 @@ impl AddressMother {
     }
 
     pub fn address() -> Address {
-        "RIMARGKZU46OZ77OLPDHHPUJ7YBSHRTCYMQUC64KZCCMESQAFQMYU6SL2Q".parse::<Address>()
+        "RIMARGKZU46OZ77OLPDHHPUJ7YBSHRTCYMQUC64KZCCMESQAFQMYU6SL2Q"
+            .parse::<Address>()
             .unwrap()
     }
 }

--- a/crates/algokit_transact/src/tests.rs
+++ b/crates/algokit_transact/src/tests.rs
@@ -1,8 +1,9 @@
 use crate::{
     test_utils::{AddressMother, TransactionMother},
-    Address, AlgorandMsgpack, SignedTransaction, Transaction, TransactionId,
+    Address, AlgorandMsgpack, SignedTransaction, Transaction, TransactionId, EstimateTransactionSize
 };
 use pretty_assertions::assert_eq;
+use crate::constants::ALGORAND_SIGNATURE_ENCODING_INCR;
 
 #[test]
 fn test_payment_transaction_encoding() {
@@ -118,4 +119,21 @@ fn test_pay_transaction_id() {
 
     assert_eq!(payment_tx.id().unwrap(), expected_tx_id);
     assert_eq!(signed_tx.id().unwrap(), expected_tx_id);
+}
+
+#[test]
+fn test_estimate_transaction_size() {
+    let tx_builder = TransactionMother::simple_payment();
+    let payment_tx = tx_builder.build().unwrap();
+    let encoding_length = payment_tx.encode_raw().unwrap().len();
+    let estimation = payment_tx.estimate_size().unwrap();
+    
+    let signed_tx = SignedTransaction {
+        transaction: payment_tx.clone(),
+        signature: [0; 64],
+    };
+    let actual_size = signed_tx.encode().unwrap().len();
+
+    assert_eq!(estimation, encoding_length + ALGORAND_SIGNATURE_ENCODING_INCR);
+    assert_eq!(estimation, actual_size);
 }

--- a/crates/algokit_transact/src/tests.rs
+++ b/crates/algokit_transact/src/tests.rs
@@ -1,9 +1,10 @@
+use crate::constants::ALGORAND_SIGNATURE_ENCODING_INCR;
 use crate::{
     test_utils::{AddressMother, TransactionMother},
-    Address, AlgorandMsgpack, SignedTransaction, Transaction, TransactionId, EstimateTransactionSize
+    Address, AlgorandMsgpack, EstimateTransactionSize, SignedTransaction, Transaction,
+    TransactionId,
 };
 use pretty_assertions::assert_eq;
-use crate::constants::ALGORAND_SIGNATURE_ENCODING_INCR;
 
 #[test]
 fn test_payment_transaction_encoding() {
@@ -127,13 +128,16 @@ fn test_estimate_transaction_size() {
     let payment_tx = tx_builder.build().unwrap();
     let encoding_length = payment_tx.encode_raw().unwrap().len();
     let estimation = payment_tx.estimate_size().unwrap();
-    
+
     let signed_tx = SignedTransaction {
         transaction: payment_tx.clone(),
         signature: [0; 64],
     };
     let actual_size = signed_tx.encode().unwrap().len();
 
-    assert_eq!(estimation, encoding_length + ALGORAND_SIGNATURE_ENCODING_INCR);
+    assert_eq!(
+        estimation,
+        encoding_length + ALGORAND_SIGNATURE_ENCODING_INCR
+    );
     assert_eq!(estimation, actual_size);
 }

--- a/crates/algokit_transact/src/traits.rs
+++ b/crates/algokit_transact/src/traits.rs
@@ -58,7 +58,7 @@ pub trait AlgorandMsgpack: Serialize + for<'de> Deserialize<'de> {
     /// * `bytes` - The MessagePack encoded bytes
     ///
     /// # Returns
-    /// The decoded instance or an AlgoKitTransactError if the input is empty or 
+    /// The decoded instance or an AlgoKitTransactError if the input is empty or
     /// deserialization fails.
     fn decode(bytes: &[u8]) -> Result<Self, AlgoKitTransactError> {
         if bytes.is_empty() {
@@ -84,7 +84,7 @@ pub trait AlgorandMsgpack: Serialize + for<'de> Deserialize<'de> {
     ///
     /// This method performs canonical encoding and prepends the domain separation
     /// prefix defined by the PREFIX constant.
-    /// 
+    ///
     /// Use `encode_raw()` if you want to encode without the prefix.
     ///
     /// # Returns
@@ -139,4 +139,8 @@ pub trait TransactionId: AlgorandMsgpack {
             &hash,
         ))
     }
+}
+
+pub trait EstimateTransactionSize: AlgorandMsgpack {
+    fn estimate_size(&self) -> Result<usize, AlgoKitTransactError>;
 }

--- a/crates/algokit_transact/src/transactions/mod.rs
+++ b/crates/algokit_transact/src/transactions/mod.rs
@@ -61,7 +61,7 @@ impl TransactionId for Transaction {}
 
 impl EstimateTransactionSize for Transaction {
     fn estimate_size(&self) -> Result<usize, AlgoKitTransactError> {
-        return Ok(self.encode()?.len() + ALGORAND_SIGNATURE_ENCODING_INCR);
+        return Ok(self.encode_raw()?.len() + ALGORAND_SIGNATURE_ENCODING_INCR);
     }
 }
 

--- a/crates/algokit_transact/src/transactions/mod.rs
+++ b/crates/algokit_transact/src/transactions/mod.rs
@@ -14,7 +14,7 @@ pub use common::{TransactionHeader, TransactionHeaderBuilder};
 use payment::PaymentTransactionBuilderError;
 pub use payment::{PaymentTransactionBuilder, PaymentTransactionFields};
 
-use crate::constants::HASH_BYTES_LENGTH;
+use crate::constants::{ALGORAND_SIGNATURE_ENCODING_INCR, HASH_BYTES_LENGTH};
 use crate::error::AlgoKitTransactError;
 use crate::traits::{AlgorandMsgpack, EstimateTransactionSize, TransactionId};
 use serde::{Deserialize, Serialize};
@@ -61,14 +61,7 @@ impl TransactionId for Transaction {}
 
 impl EstimateTransactionSize for Transaction {
     fn estimate_size(&self) -> Result<usize, AlgoKitTransactError> {
-        // We are simulating a signature on this transaction in order to encode it, and get the size
-        //  with which we will be able to estimate the fee.
-        let signed_tx = SignedTransaction {
-            transaction: self.clone(),
-            // Avoiding a zero signature just in case it's compressed or removed in the encoding.
-            signature: [1; 64],
-        };
-        return Ok(signed_tx.encode()?.len());
+        return Ok(self.encode()?.len() + ALGORAND_SIGNATURE_ENCODING_INCR);
     }
 }
 

--- a/crates/algokit_transact_ffi/src/lib.rs
+++ b/crates/algokit_transact_ffi/src/lib.rs
@@ -437,7 +437,8 @@ pub fn address_from_pub_key(pub_key: &[u8]) -> Result<Address, AlgoKitTransactEr
 
 #[ffi_func]
 pub fn address_from_string(address: &str) -> Result<Address, AlgoKitTransactError> {
-    address.parse::<algokit_transact::Address>()
+    address
+        .parse::<algokit_transact::Address>()
         .map(Into::into)
         .map_err(|e| AlgoKitTransactError::EncodingError(e.to_string()))
 }


### PR DESCRIPTION
I thought this code is common enough we might want it in core.

I am still missing a way to do it in the rust crate. After I do that, the FFI crate should only re-expose what's in the core crate.

Also, I haven't taken the approach of actually signing it as it is a slow operation. I decided to attach an invalid signature, encode, and get the size.

I've also seen a bunch of times just adding `75` to the encoding length without a signature. I am assuming `75` comes up from the field name, the encoding and the signature length.
What approach do we think is best?