### PR TITLE
build: adjust py api ci/cd to do less when not doing a release

### DIFF
--- a/.github/workflows/python_api_client_ci_cd.yml
+++ b/.github/workflows/python_api_client_ci_cd.yml
@@ -39,6 +39,7 @@ jobs:
         working-directory: ${{ env.PACKAGE_DIR }}
     steps:
       - uses: actions/create-github-app-token@v1
+        if: inputs.release
         id: app_token
         with:
           app-id: ${{ secrets.BOT_ID }}
@@ -47,7 +48,9 @@ jobs:
         with:
           ref: ${{ github.ref }}
           token: ${{ steps.app_token.outputs.token }}
+        if: inputs.release
       - uses: oven-sh/setup-bun@v2
+        if: inputs.release
         with:
           bun-version: latest
       - working-directory: "."
@@ -71,6 +74,7 @@ jobs:
         run: |
           sed -i 's/packageVersion: .*/packageVersion: "${{ steps.convert_version.outputs.version }}"/' api/oas_templates/python/openapi-config.yaml
       - working-directory: api
+        if: steps.semantic_release.outputs.version != ''
         run: |
           bun install --frozen-lockfile
           bun run generate:${{ inputs.api }}:py
@@ -217,6 +221,7 @@ jobs:
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
+          token: ${{ steps.app_token.outputs.token }}
       - name: Reset branch
         if: needs.get_version.outputs.version_commit_sha != ''
         env:

--- a/.github/workflows/python_uniffi_ci_cd.yml
+++ b/.github/workflows/python_uniffi_ci_cd.yml
@@ -315,6 +315,7 @@ jobs:
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
+          token: ${{ steps.app_token.outputs.token }}
       - name: Reset branch
         if: needs.get_version.outputs.version_commit_sha != ''
         env:


### PR DESCRIPTION
- Only run the steps in get_version when a release can be performed
- Add token to git checkout when running the cleanup step