### PR TITLE
build: use bunx instead of npx

### DIFF
--- a/scripts/build/languages/typescript.ts
+++ b/scripts/build/languages/typescript.ts
@@ -2,7 +2,7 @@ import { run } from "..";
 import * as fs from "fs";
 
 async function wasmPack(crate: string, target: "web" | "nodejs" | "bundler", cwd: string) {
-  const cmd = `npx wasm-pack build --out-dir ../../packages/typescript/${crate}/pkg --mode normal --release --target ${target} ../../../crates/${crate}_ffi --no-default-features --features ffi_wasm`;
+  const cmd = `bunx wasm-pack build --out-dir ../../packages/typescript/${crate}/pkg --mode normal --release --target ${target} ../../../crates/${crate}_ffi --no-default-features --features ffi_wasm`;
 
   await run(cmd, cwd, {
     // Needed due to Rust 1.82+ using LLVM with reference-types enabled by default, which makes the WASM binary incompatible with wasm2js
@@ -21,7 +21,7 @@ async function build(crate: string, mode: "esm" | "cjs" | "wasm2js", cwd: string
       break;
     case "wasm2js":
       await wasmPack(crate, "bundler", cwd);
-      await run(`npx wasm2js -O pkg/${crate}_ffi_bg.wasm -o pkg/${crate}_ffi_bg.wasm.js`, cwd);
+      await run(`bunx wasm2js -O pkg/${crate}_ffi_bg.wasm -o pkg/${crate}_ffi_bg.wasm.js`, cwd);
 
       // Replace references to the wasm file with the wasm2js file
       [".js", "_bg.js"].forEach((ext) => {
@@ -43,7 +43,7 @@ async function build(crate: string, mode: "esm" | "cjs" | "wasm2js", cwd: string
       throw new Error(`Unknown mode ${mode}`);
   }
 
-  await run(`npx rollup -c rollup.config.${mode}.mjs`, cwd);
+  await run(`bunx rollup -c rollup.config.${mode}.mjs`, cwd);
 }
 
 export async function buildTypescript(crate: string) {


### PR DESCRIPTION
This seems to be an issue with Windows. When the packages are installed with `bun` and run with `npx`, the `wasm2js` command doesn't accept the `-O` flag. 
![image](https://github.com/user-attachments/assets/c40a5c4a-a2ae-4d36-ba59-ea2fe9c75291)
If I use `bunx` to run the command, I get the same behaviour with Mac and Linux, where it works.

I think that seen we are using `bun`, let's use `bunx` instead of `npx` for more consistent experience.