### PR TITLE
feat: add encode, decode and sign support for transaction groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,7 @@ version = "0.1.0"
 dependencies = [
  "algokit_transact",
  "ffi_macros",
+ "js-sys",
  "pretty_assertions",
  "rmp-serde",
  "serde",
@@ -1737,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3666,20 +3667,21 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -3691,9 +3693,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3701,9 +3703,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3714,9 +3716,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-pack"
@@ -3752,9 +3757,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ uniffi = { version = "0.28.3" }
 thiserror = { version = "2.0.7" }
 wasm-bindgen = { version = "0.2.99" }
 tsify-next = { version = "0.5.4", features = ["js"] }
+js-sys = { version = "0.3.77" }
 
 [workspace.metadata.bin]
 polytest = { version = "0.3.0", locked = true }

--- a/crates/algokit_transact/src/lib.rs
+++ b/crates/algokit_transact/src/lib.rs
@@ -9,9 +9,7 @@ mod utils;
 pub use address::Address;
 pub use constants::*;
 pub use error::AlgoKitTransactError;
-pub use traits::{
-    AlgorandMsgpack, EstimateTransactionSize, SignedTransactions, TransactionId, Transactions,
-};
+pub use traits::{AlgorandMsgpack, EstimateTransactionSize, TransactionId, Transactions};
 pub use transactions::{
     AssetTransferTransactionBuilder, AssetTransferTransactionFields, FeeParams,
     PaymentTransactionBuilder, PaymentTransactionFields, SignedTransaction, Transaction,

--- a/crates/algokit_transact/src/lib.rs
+++ b/crates/algokit_transact/src/lib.rs
@@ -9,7 +9,9 @@ mod utils;
 pub use address::Address;
 pub use constants::*;
 pub use error::AlgoKitTransactError;
-pub use traits::{AlgorandMsgpack, EstimateTransactionSize, Transactions, TransactionId};
+pub use traits::{
+    AlgorandMsgpack, EstimateTransactionSize, SignedTransactions, TransactionId, Transactions,
+};
 pub use transactions::{
     AssetTransferTransactionBuilder, AssetTransferTransactionFields, FeeParams,
     PaymentTransactionBuilder, PaymentTransactionFields, SignedTransaction, Transaction,

--- a/crates/algokit_transact/src/tests.rs
+++ b/crates/algokit_transact/src/tests.rs
@@ -1,11 +1,13 @@
-use crate::constants::{ALGORAND_SIGNATURE_BYTE_LENGTH, ALGORAND_SIGNATURE_ENCODING_INCR};
-use crate::test_utils::{TransactionGroupMother, TransactionHeaderMother};
-use crate::FeeParams;
-use crate::MAX_TX_GROUP_SIZE;
 use crate::{
-    test_utils::{AddressMother, TransactionMother},
-    Address, AlgorandMsgpack, EstimateTransactionSize, SignedTransaction, Transaction,
-    TransactionId, Transactions,
+    constants::{
+        ALGORAND_SIGNATURE_BYTE_LENGTH, ALGORAND_SIGNATURE_ENCODING_INCR, MAX_TX_GROUP_SIZE,
+    },
+    test_utils::{
+        AddressMother, TransactionGroupMother, TransactionHeaderMother, TransactionMother,
+    },
+    transactions::FeeParams,
+    Address, AlgorandMsgpack, EstimateTransactionSize, SignedTransaction, SignedTransactions,
+    Transaction, TransactionId, Transactions,
 };
 use base64::{prelude::BASE64_STANDARD, Engine};
 use pretty_assertions::assert_eq;
@@ -325,4 +327,48 @@ fn test_transaction_group_already_set() {
     assert!(error
         .to_string()
         .starts_with("Transactions must not already be grouped"));
+}
+
+#[test]
+fn test_transaction_group_encoding() {
+    let grouped_txs = TransactionGroupMother::testnet_payment_group()
+        .assign_group()
+        .unwrap();
+
+    let encoded_grouped_txs = grouped_txs.encode().unwrap();
+    let decoded_grouped_txs = Vec::<Transaction>::decode(&encoded_grouped_txs).unwrap();
+
+    for ((grouped_tx, encoded_tx), decoded_tx) in grouped_txs
+        .iter()
+        .zip(encoded_grouped_txs.into_iter())
+        .zip(decoded_grouped_txs.iter())
+    {
+        assert_eq!(encoded_tx, grouped_tx.encode().unwrap());
+        assert_eq!(decoded_tx, grouped_tx);
+    }
+}
+
+#[test]
+fn test_signed_transaction_group_encoding() {
+    let signed_grouped_txs = TransactionGroupMother::testnet_payment_group()
+        .assign_group()
+        .unwrap()
+        .iter()
+        .map(|tx| SignedTransaction {
+            transaction: tx.clone(),
+            signature: [0; ALGORAND_SIGNATURE_BYTE_LENGTH],
+        })
+        .collect::<Vec<SignedTransaction>>();
+
+    let encoded_signed_group = signed_grouped_txs.encode().unwrap();
+    let decoded_signed_group = Vec::<SignedTransaction>::decode(&encoded_signed_group).unwrap();
+
+    for ((signed_grouped_tx, encoded_signed_tx), decoded_signed_tx) in signed_grouped_txs
+        .iter()
+        .zip(encoded_signed_group.into_iter())
+        .zip(decoded_signed_group.iter())
+    {
+        assert_eq!(encoded_signed_tx, signed_grouped_tx.encode().unwrap());
+        assert_eq!(decoded_signed_tx, signed_grouped_tx);
+    }
 }

--- a/crates/algokit_transact/src/tests.rs
+++ b/crates/algokit_transact/src/tests.rs
@@ -6,8 +6,8 @@ use crate::{
         AddressMother, TransactionGroupMother, TransactionHeaderMother, TransactionMother,
     },
     transactions::FeeParams,
-    Address, AlgorandMsgpack, EstimateTransactionSize, SignedTransaction, SignedTransactions,
-    Transaction, TransactionId, Transactions,
+    Address, AlgorandMsgpack, EstimateTransactionSize, SignedTransaction, Transaction,
+    TransactionId, Transactions,
 };
 use base64::{prelude::BASE64_STANDARD, Engine};
 use pretty_assertions::assert_eq;
@@ -335,8 +335,16 @@ fn test_transaction_group_encoding() {
         .assign_group()
         .unwrap();
 
-    let encoded_grouped_txs = grouped_txs.encode().unwrap();
-    let decoded_grouped_txs = <&[Transaction]>::decode(&encoded_grouped_txs).unwrap();
+    let encoded_grouped_txs = grouped_txs
+        .iter()
+        .map(|tx| tx.encode())
+        .collect::<Result<Vec<Vec<u8>>, _>>()
+        .unwrap();
+    let decoded_grouped_txs = encoded_grouped_txs
+        .iter()
+        .map(|tx| Transaction::decode(tx))
+        .collect::<Result<Vec<Transaction>, _>>()
+        .unwrap();
 
     for ((grouped_tx, encoded_tx), decoded_tx) in grouped_txs
         .iter()
@@ -361,8 +369,16 @@ fn test_signed_transaction_group_encoding() {
         })
         .collect::<Vec<SignedTransaction>>();
 
-    let encoded_signed_group = signed_grouped_txs.encode().unwrap();
-    let decoded_signed_group = <&[SignedTransaction]>::decode(&encoded_signed_group).unwrap();
+    let encoded_signed_group = signed_grouped_txs
+        .iter()
+        .map(|tx| tx.encode())
+        .collect::<Result<Vec<Vec<u8>>, _>>()
+        .unwrap();
+    let decoded_signed_group = encoded_signed_group
+        .iter()
+        .map(|tx| SignedTransaction::decode(tx))
+        .collect::<Result<Vec<SignedTransaction>, _>>()
+        .unwrap();
 
     for ((signed_grouped_tx, encoded_signed_tx), decoded_signed_tx) in signed_grouped_txs
         .iter()

--- a/crates/algokit_transact/src/tests.rs
+++ b/crates/algokit_transact/src/tests.rs
@@ -336,7 +336,7 @@ fn test_transaction_group_encoding() {
         .unwrap();
 
     let encoded_grouped_txs = grouped_txs.encode().unwrap();
-    let decoded_grouped_txs = Vec::<Transaction>::decode(&encoded_grouped_txs).unwrap();
+    let decoded_grouped_txs = <&[Transaction]>::decode(&encoded_grouped_txs).unwrap();
 
     for ((grouped_tx, encoded_tx), decoded_tx) in grouped_txs
         .iter()
@@ -356,12 +356,13 @@ fn test_signed_transaction_group_encoding() {
         .iter()
         .map(|tx| SignedTransaction {
             transaction: tx.clone(),
-            signature: [0; ALGORAND_SIGNATURE_BYTE_LENGTH],
+            signature: Some([0; ALGORAND_SIGNATURE_BYTE_LENGTH]),
+            auth_address: None,
         })
         .collect::<Vec<SignedTransaction>>();
 
     let encoded_signed_group = signed_grouped_txs.encode().unwrap();
-    let decoded_signed_group = Vec::<SignedTransaction>::decode(&encoded_signed_group).unwrap();
+    let decoded_signed_group = <&[SignedTransaction]>::decode(&encoded_signed_group).unwrap();
 
     for ((signed_grouped_tx, encoded_signed_tx), decoded_signed_tx) in signed_grouped_txs
         .iter()

--- a/crates/algokit_transact/src/tests.rs
+++ b/crates/algokit_transact/src/tests.rs
@@ -324,5 +324,5 @@ fn test_transaction_group_already_set() {
     let error = result.unwrap_err();
     assert!(error
         .to_string()
-        .starts_with("Transactions must not already be grouped"));
+        .starts_with("Transactions must not be already grouped"));
 }

--- a/crates/algokit_transact/src/tests.rs
+++ b/crates/algokit_transact/src/tests.rs
@@ -324,5 +324,5 @@ fn test_transaction_group_already_set() {
     let error = result.unwrap_err();
     assert!(error
         .to_string()
-        .starts_with("Transactions must not be already grouped"));
+        .starts_with("Transactions must not already be grouped"));
 }

--- a/crates/algokit_transact/src/traits.rs
+++ b/crates/algokit_transact/src/traits.rs
@@ -156,7 +156,7 @@ pub trait Transactions: Sized {
     ///
     /// # Returns
     /// The encoded bytes with prefix for the supplied transactions or an AlgoKitTransactError if serialization fails.
-    fn encode(&self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError>;
+    fn encode(self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError>;
 
     /// Encodes the supplied transactions to MessagePack format without any prefix.
     ///
@@ -165,7 +165,7 @@ pub trait Transactions: Sized {
     ///
     /// # Returns
     /// The raw encoded bytes for the supplied transactions or an AlgoKitTransactError if serialization fails.
-    fn encode_raw(&self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError>;
+    fn encode_raw(self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError>;
 
     /// Decodes a collection of MessagePack bytes into a transaction collection.
     ///
@@ -178,18 +178,18 @@ pub trait Transactions: Sized {
     /// # Returns
     /// The decoded transactions or an AlgoKitTransactError if the input is empty or
     /// deserialization fails.
-    fn decode(encoded_txs: &Vec<Vec<u8>>) -> Result<Vec<Transaction>, AlgoKitTransactError>;
+    fn decode(encoded_txs: &[Vec<u8>]) -> Result<Vec<Transaction>, AlgoKitTransactError>;
 }
 
 /// Trait for operations which pertain to a collection of signed transactions.
-pub trait SignedTransactions {
+pub trait SignedTransactions: Sized {
     /// Encodes the supplied signed transactions to MessagePack format.
     ///
     /// This method performs canonical encoding. No domain separation prefix is applicable.
     ///
     /// # Returns
     /// The encoded bytes for the supplied signed transactions or an AlgoKitTransactError if serialization fails.
-    fn encode(&self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError>;
+    fn encode(self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError>;
 
     /// Decodes a collection of MessagePack bytes into a signed transaction collection.
     ///
@@ -199,5 +199,5 @@ pub trait SignedTransactions {
     /// # Returns
     /// The decoded signed transactions or an AlgoKitTransactError if the input is empty or
     /// deserialization fails.
-    fn decode(encoded_txs: &Vec<Vec<u8>>) -> Result<Vec<SignedTransaction>, AlgoKitTransactError>;
+    fn decode(encoded_txs: &[Vec<u8>]) -> Result<Vec<SignedTransaction>, AlgoKitTransactError>;
 }

--- a/crates/algokit_transact/src/traits.rs
+++ b/crates/algokit_transact/src/traits.rs
@@ -5,8 +5,8 @@
 
 use crate::error::AlgoKitTransactError;
 use crate::utils::sort_msgpack_value;
+use crate::Transaction;
 use crate::{constants::HASH_BYTES_LENGTH, utils::hash};
-use crate::{SignedTransaction, Transaction};
 use serde::{Deserialize, Serialize};
 
 /// Trait for Algorand MessagePack encoding and decoding.
@@ -147,57 +147,4 @@ pub trait Transactions: Sized {
     /// # Returns
     /// A result containing the transactions with group assign or an error if grouping fails.
     fn assign_group(self) -> Result<Vec<Transaction>, AlgoKitTransactError>;
-
-    /// Encodes the supplied transactions to MessagePack format with the appropriate prefix (TX).
-    ///
-    /// This method performs canonical encoding and prepends the domain separation
-    ///
-    /// Use `encode_raw()` if you want to encode without the prefix.
-    ///
-    /// # Returns
-    /// The encoded bytes with prefix for the supplied transactions or an AlgoKitTransactError if serialization fails.
-    fn encode(self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError>;
-
-    /// Encodes the supplied transactions to MessagePack format without any prefix.
-    ///
-    /// This method performs canonical encoding with sorted map keys and omitted empty fields,
-    /// but does not include any domain separation prefix.
-    ///
-    /// # Returns
-    /// The raw encoded bytes for the supplied transactions or an AlgoKitTransactError if serialization fails.
-    fn encode_raw(self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError>;
-
-    /// Decodes a collection of MessagePack bytes into a transaction collection.
-    ///
-    /// If the bytes start with the expected PREFIX for this type, the prefix is
-    /// automatically removed before decoding.
-    ///
-    /// # Parameters
-    /// * `encoded_txs` - A collection of MessagePack encoded bytes, each representing a transaction.
-    ///
-    /// # Returns
-    /// The decoded transactions or an AlgoKitTransactError if the input is empty or
-    /// deserialization fails.
-    fn decode(encoded_txs: &[Vec<u8>]) -> Result<Vec<Transaction>, AlgoKitTransactError>;
-}
-
-/// Trait for operations which pertain to a collection of signed transactions.
-pub trait SignedTransactions: Sized {
-    /// Encodes the supplied signed transactions to MessagePack format.
-    ///
-    /// This method performs canonical encoding. No domain separation prefix is applicable.
-    ///
-    /// # Returns
-    /// The encoded bytes for the supplied signed transactions or an AlgoKitTransactError if serialization fails.
-    fn encode(self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError>;
-
-    /// Decodes a collection of MessagePack bytes into a signed transaction collection.
-    ///
-    /// # Parameters
-    /// * `encoded_txs` - A collection of MessagePack encoded bytes, each representing a signed transaction.
-    ///
-    /// # Returns
-    /// The decoded signed transactions or an AlgoKitTransactError if the input is empty or
-    /// deserialization fails.
-    fn decode(encoded_txs: &[Vec<u8>]) -> Result<Vec<SignedTransaction>, AlgoKitTransactError>;
 }

--- a/crates/algokit_transact/src/transactions/mod.rs
+++ b/crates/algokit_transact/src/transactions/mod.rs
@@ -21,7 +21,7 @@ use crate::constants::{
 use crate::error::AlgoKitTransactError;
 use crate::traits::{AlgorandMsgpack, EstimateTransactionSize, TransactionId, Transactions};
 use crate::utils::{compute_group_id, is_zero_addr_opt};
-use crate::Address;
+use crate::{Address, SignedTransactions};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, Bytes};
 use std::any::Any;
@@ -233,5 +233,95 @@ impl Transactions for &[Transaction] {
                 tx
             })
             .collect())
+    }
+
+    /// Encodes the supplied transactions to MessagePack format with the appropriate prefix (TX).
+    ///
+    /// This method performs canonical encoding and prepends the domain separation
+    ///
+    /// Use `encode_raw()` if you want to encode without the prefix.
+    ///
+    /// # Returns
+    /// The encoded bytes with prefix for the supplied transactions or an AlgoKitTransactError if serialization fails.
+    fn encode(&self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError> {
+        self.iter()
+            .map(|tx| tx.encode())
+            .collect::<Result<Vec<Vec<u8>>, AlgoKitTransactError>>()
+    }
+
+    /// Encodes the supplied transactions to MessagePack format without any prefix.
+    ///
+    /// This method performs canonical encoding with sorted map keys and omitted empty fields,
+    /// but does not include any domain separation prefix.
+    ///
+    /// # Returns
+    /// The raw encoded bytes for the supplied transactions or an AlgoKitTransactError if serialization fails.
+    fn encode_raw(&self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError> {
+        self.iter()
+            .map(|tx| tx.encode_raw())
+            .collect::<Result<Vec<Vec<u8>>, AlgoKitTransactError>>()
+    }
+
+    /// Decodes a collection of MessagePack bytes into a transaction collection.
+    ///
+    /// If the bytes start with the expected PREFIX for this type, the prefix is
+    /// automatically removed before decoding.
+    ///
+    /// # Parameters
+    /// * `encoded_txs` - A collection of MessagePack encoded bytes, each representing a transaction.
+    ///
+    /// # Returns
+    /// The decoded transactions or an AlgoKitTransactError if the input is empty or
+    /// deserialization fails.
+    fn decode(encoded_txs: &Vec<Vec<u8>>) -> Result<Vec<Transaction>, AlgoKitTransactError> {
+        if encoded_txs.is_empty() {
+            return Err(AlgoKitTransactError::InputError(
+                "attempted to decode 0 bytes".to_string(),
+            ));
+        }
+
+        let txs = encoded_txs
+            .iter()
+            .map(|bytes| Transaction::decode(bytes))
+            .collect::<Result<Vec<Transaction>, AlgoKitTransactError>>()?;
+
+        Ok(txs)
+    }
+}
+
+impl SignedTransactions for Vec<SignedTransaction> {
+    /// Encodes the supplied signed transactions to MessagePack format.
+    ///
+    /// This method performs canonical encoding. No domain separation prefix is applicable.
+    ///
+    /// # Returns
+    /// The encoded bytes for the supplied signed transactions or an AlgoKitTransactError if serialization fails.
+    fn encode(&self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError> {
+        self.iter()
+            .map(|stx| stx.encode())
+            .collect::<Result<Vec<Vec<u8>>, AlgoKitTransactError>>()
+    }
+
+    /// Decodes a collection of MessagePack bytes into a signed transaction collection.
+    ///
+    /// # Parameters
+    /// * `encoded_txs` - A collection of MessagePack encoded bytes, each representing a signed transaction.
+    ///
+    /// # Returns
+    /// The decoded signed transactions or an AlgoKitTransactError if the input is empty or
+    /// deserialization fails.
+    fn decode(encoded_txs: &Vec<Vec<u8>>) -> Result<Vec<SignedTransaction>, AlgoKitTransactError> {
+        if encoded_txs.is_empty() {
+            return Err(AlgoKitTransactError::InputError(
+                "attempted to decode 0 bytes".to_string(),
+            ));
+        }
+
+        let stxs = encoded_txs
+            .iter()
+            .map(|bytes| SignedTransaction::decode(bytes))
+            .collect::<Result<Vec<SignedTransaction>, AlgoKitTransactError>>()?;
+
+        Ok(stxs)
     }
 }

--- a/crates/algokit_transact/src/transactions/mod.rs
+++ b/crates/algokit_transact/src/transactions/mod.rs
@@ -21,7 +21,7 @@ use crate::constants::{
 use crate::error::AlgoKitTransactError;
 use crate::traits::{AlgorandMsgpack, EstimateTransactionSize, TransactionId, Transactions};
 use crate::utils::{compute_group_id, is_zero_addr_opt};
-use crate::{Address, SignedTransactions};
+use crate::Address;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, Bytes};
 use std::any::Any;
@@ -233,100 +233,5 @@ impl Transactions for &[Transaction] {
                 tx
             })
             .collect())
-    }
-
-    /// Encodes the supplied transactions to MsgPack format with the appropriate prefix (TX).
-    ///
-    /// This method performs canonical encoding and prepends the domain separation
-    ///
-    /// Use `encode_raw()` if you want to encode without the prefix.
-    ///
-    /// # Returns
-    /// The encoded bytes with prefix for the supplied transactions or an AlgoKitTransactError if serialization fails.
-    fn encode(self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError> {
-        self.iter()
-            .map(|tx| tx.encode())
-            .collect::<Result<Vec<Vec<u8>>, AlgoKitTransactError>>()
-    }
-
-    /// Encodes the supplied transactions to MsgPack format without any prefix.
-    ///
-    /// This method performs canonical encoding with sorted map keys and omitted empty fields,
-    /// but does not include any domain separation prefix.
-    ///
-    /// # Returns
-    /// The raw encoded bytes for the supplied transactions or an AlgoKitTransactError if serialization fails.
-    fn encode_raw(self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError> {
-        self.iter()
-            .map(|tx| tx.encode_raw())
-            .collect::<Result<Vec<Vec<u8>>, AlgoKitTransactError>>()
-    }
-
-    /// Decodes a collection of MsgPack bytes into a transaction collection.
-    ///
-    /// If the bytes start with the expected PREFIX for this type, the prefix is
-    /// automatically removed before decoding.
-    ///
-    /// # Parameters
-    /// * `encoded_txs` - A collection of MsgPack encoded bytes, each representing a transaction.
-    ///
-    /// # Returns
-    /// The decoded transactions or an AlgoKitTransactError if the input is empty or
-    /// deserialization fails.
-    fn decode(encoded_txs: &[Vec<u8>]) -> Result<Vec<Transaction>, AlgoKitTransactError> {
-        if encoded_txs.is_empty() {
-            return Err(AlgoKitTransactError::InputError(
-                "attempted to decode 0 bytes".to_string(),
-            ));
-        }
-
-        let txs = encoded_txs
-            .iter()
-            .map(|bytes| Transaction::decode(bytes))
-            .collect::<Result<Vec<Transaction>, AlgoKitTransactError>>()?;
-
-        Ok(txs)
-    }
-}
-
-impl SignedTransactions for &[SignedTransaction] {
-    /// Encodes signed transactions to MsgPack for sending on the network.
-    ///
-    /// This method performs canonical encoding. No domain separation prefix is applicable.
-    ///
-    /// # Parameters
-    /// * `self` - A collection of signed transactions to encode
-    ///
-    /// # Returns
-    /// A collection of MsgPack encoded bytes or an AlgoKitTransactError if serialization fails.
-    fn encode(self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError> {
-        self.iter()
-            .map(|stx| stx.encode())
-            .collect::<Result<Vec<Vec<u8>>, AlgoKitTransactError>>()
-    }
-
-    /// Decodes a collection of MsgPack bytes into a signed transaction collection.
-    ///
-    /// # Parameters
-    /// * `encoded_signed_txs` - A collection of MsgPack encoded bytes, each representing a signed transaction.
-    ///
-    /// # Returns
-    /// A collection of decoded SignedTransaction or an AlgoKitTransactError if the input is empty or
-    /// deserialization fails.
-    fn decode(
-        encoded_signed_txs: &[Vec<u8>],
-    ) -> Result<Vec<SignedTransaction>, AlgoKitTransactError> {
-        if encoded_signed_txs.is_empty() {
-            return Err(AlgoKitTransactError::InputError(
-                "attempted to decode 0 bytes".to_string(),
-            ));
-        }
-
-        let stxs = encoded_signed_txs
-            .iter()
-            .map(|bytes| SignedTransaction::decode(bytes))
-            .collect::<Result<Vec<SignedTransaction>, AlgoKitTransactError>>()?;
-
-        Ok(stxs)
     }
 }

--- a/crates/algokit_transact/src/transactions/mod.rs
+++ b/crates/algokit_transact/src/transactions/mod.rs
@@ -148,10 +148,10 @@ pub struct SignedTransaction {
 }
 
 impl AlgorandMsgpack for SignedTransaction {
-    /// Decodes MessagePack bytes into a SignedTransaction.
+    /// Decodes MsgPack bytes into a SignedTransaction.
     ///
     /// # Parameters
-    /// * `bytes` - The MessagePack encoded signed transaction bytes
+    /// * `bytes` - The MsgPack encoded signed transaction bytes
     ///
     /// # Returns
     /// The decoded SignedTransaction or an error if decoding fails or the transaction type is not recognized.
@@ -235,7 +235,7 @@ impl Transactions for &[Transaction] {
             .collect())
     }
 
-    /// Encodes the supplied transactions to MessagePack format with the appropriate prefix (TX).
+    /// Encodes the supplied transactions to MsgPack format with the appropriate prefix (TX).
     ///
     /// This method performs canonical encoding and prepends the domain separation
     ///
@@ -243,37 +243,37 @@ impl Transactions for &[Transaction] {
     ///
     /// # Returns
     /// The encoded bytes with prefix for the supplied transactions or an AlgoKitTransactError if serialization fails.
-    fn encode(&self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError> {
+    fn encode(self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError> {
         self.iter()
             .map(|tx| tx.encode())
             .collect::<Result<Vec<Vec<u8>>, AlgoKitTransactError>>()
     }
 
-    /// Encodes the supplied transactions to MessagePack format without any prefix.
+    /// Encodes the supplied transactions to MsgPack format without any prefix.
     ///
     /// This method performs canonical encoding with sorted map keys and omitted empty fields,
     /// but does not include any domain separation prefix.
     ///
     /// # Returns
     /// The raw encoded bytes for the supplied transactions or an AlgoKitTransactError if serialization fails.
-    fn encode_raw(&self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError> {
+    fn encode_raw(self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError> {
         self.iter()
             .map(|tx| tx.encode_raw())
             .collect::<Result<Vec<Vec<u8>>, AlgoKitTransactError>>()
     }
 
-    /// Decodes a collection of MessagePack bytes into a transaction collection.
+    /// Decodes a collection of MsgPack bytes into a transaction collection.
     ///
     /// If the bytes start with the expected PREFIX for this type, the prefix is
     /// automatically removed before decoding.
     ///
     /// # Parameters
-    /// * `encoded_txs` - A collection of MessagePack encoded bytes, each representing a transaction.
+    /// * `encoded_txs` - A collection of MsgPack encoded bytes, each representing a transaction.
     ///
     /// # Returns
     /// The decoded transactions or an AlgoKitTransactError if the input is empty or
     /// deserialization fails.
-    fn decode(encoded_txs: &Vec<Vec<u8>>) -> Result<Vec<Transaction>, AlgoKitTransactError> {
+    fn decode(encoded_txs: &[Vec<u8>]) -> Result<Vec<Transaction>, AlgoKitTransactError> {
         if encoded_txs.is_empty() {
             return Err(AlgoKitTransactError::InputError(
                 "attempted to decode 0 bytes".to_string(),
@@ -289,35 +289,40 @@ impl Transactions for &[Transaction] {
     }
 }
 
-impl SignedTransactions for Vec<SignedTransaction> {
-    /// Encodes the supplied signed transactions to MessagePack format.
+impl SignedTransactions for &[SignedTransaction] {
+    /// Encodes signed transactions to MsgPack for sending on the network.
     ///
     /// This method performs canonical encoding. No domain separation prefix is applicable.
     ///
+    /// # Parameters
+    /// * `self` - A collection of signed transactions to encode
+    ///
     /// # Returns
-    /// The encoded bytes for the supplied signed transactions or an AlgoKitTransactError if serialization fails.
-    fn encode(&self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError> {
+    /// A collection of MsgPack encoded bytes or an AlgoKitTransactError if serialization fails.
+    fn encode(self) -> Result<Vec<Vec<u8>>, AlgoKitTransactError> {
         self.iter()
             .map(|stx| stx.encode())
             .collect::<Result<Vec<Vec<u8>>, AlgoKitTransactError>>()
     }
 
-    /// Decodes a collection of MessagePack bytes into a signed transaction collection.
+    /// Decodes a collection of MsgPack bytes into a signed transaction collection.
     ///
     /// # Parameters
-    /// * `encoded_txs` - A collection of MessagePack encoded bytes, each representing a signed transaction.
+    /// * `encoded_signed_txs` - A collection of MsgPack encoded bytes, each representing a signed transaction.
     ///
     /// # Returns
-    /// The decoded signed transactions or an AlgoKitTransactError if the input is empty or
+    /// A collection of decoded SignedTransaction or an AlgoKitTransactError if the input is empty or
     /// deserialization fails.
-    fn decode(encoded_txs: &Vec<Vec<u8>>) -> Result<Vec<SignedTransaction>, AlgoKitTransactError> {
-        if encoded_txs.is_empty() {
+    fn decode(
+        encoded_signed_txs: &[Vec<u8>],
+    ) -> Result<Vec<SignedTransaction>, AlgoKitTransactError> {
+        if encoded_signed_txs.is_empty() {
             return Err(AlgoKitTransactError::InputError(
                 "attempted to decode 0 bytes".to_string(),
             ));
         }
 
-        let stxs = encoded_txs
+        let stxs = encoded_signed_txs
             .iter()
             .map(|bytes| SignedTransaction::decode(bytes))
             .collect::<Result<Vec<SignedTransaction>, AlgoKitTransactError>>()?;

--- a/crates/algokit_transact_ffi/Cargo.toml
+++ b/crates/algokit_transact_ffi/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib", "staticlib"]
 
 [features]
 default = ["ffi_uniffi"]
-ffi_wasm = ["dep:wasm-bindgen", "dep:tsify-next"]
+ffi_wasm = ["dep:wasm-bindgen", "dep:tsify-next", "dep:js-sys"]
 ffi_uniffi = ["dep:uniffi"]
 
 [dependencies]
@@ -25,6 +25,7 @@ uniffi = { workspace = true, features = [
   "scaffolding-ffi-buffer-fns",
 ], optional = true }
 wasm-bindgen = { workspace = true, optional = true }
+js-sys = { workspace = true, optional = true }
 pretty_assertions = "1.4.1"
 
 
@@ -43,4 +44,5 @@ serde = { version = "1.0.216", features = ["derive"] }
 serde_bytes = "0.11.15"
 serde_json = "1.0.133"
 tsify-next = { workspace = true, optional = true }
+js-sys = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }

--- a/crates/algokit_transact_ffi/polytest.toml
+++ b/crates/algokit_transact_ffi/polytest.toml
@@ -69,6 +69,12 @@ desc = "Tests that apply to collections of transactions"
 [group."Transaction Group Tests".test."group transactions"]
 desc = "A collection of transactions can be grouped"
 
+[group."Transaction Group Tests".test."encode transactions"]
+desc = "A collection of transactions can be encoded"
+
+[group."Transaction Group Tests".test."encode transactions with signatures"]
+desc = "Signatures can be attached to a collection of encoded transactions"
+
 # Test Targets
 
 [target.bun]

--- a/crates/algokit_transact_ffi/polytest.toml
+++ b/crates/algokit_transact_ffi/polytest.toml
@@ -72,8 +72,8 @@ desc = "A collection of transactions can be grouped"
 [group."Transaction Group Tests".test."encode transactions"]
 desc = "A collection of transactions can be encoded"
 
-[group."Transaction Group Tests".test."encode transactions with signatures"]
-desc = "Signatures can be attached to a collection of encoded transactions"
+[group."Transaction Group Tests".test."encode signed transactions"]
+desc = "A collection of signed transactions can be encoded"
 
 # Test Targets
 

--- a/crates/algokit_transact_ffi/test_plan.md
+++ b/crates/algokit_transact_ffi/test_plan.md
@@ -1,4 +1,5 @@
 # Polytest Test Plan
+
 ## Test Suites
 
 ### Payment
@@ -47,7 +48,7 @@
 | --- | --- |
 | [group transactions](#group-transactions) | A collection of transactions can be grouped |
 | [encode transactions](#encode-transactions) | A collection of transactions can be encoded |
-| [encode transactions with signatures](#encode-transactions-with-signatures) | Signatures can be attached to a collection of encoded transactions |
+| [encode signed transactions](#encode-signed-transactions) | A collection of signed transactions can be encoded |
 
 ## Test Cases
 
@@ -99,6 +100,6 @@ A collection of transactions can be grouped
 
 A collection of transactions can be encoded
 
-### encode transactions with signatures
+### encode signed transactions
 
-Signatures can be attached to a collection of encoded transactions
+A collection of signed transactions can be encoded

--- a/crates/algokit_transact_ffi/test_plan.md
+++ b/crates/algokit_transact_ffi/test_plan.md
@@ -46,6 +46,8 @@
 | Name | Description |
 | --- | --- |
 | [group transactions](#group-transactions) | A collection of transactions can be grouped |
+| [encode transactions](#encode-transactions) | A collection of transactions can be encoded |
+| [encode transactions with signatures](#encode-transactions-with-signatures) | Signatures can be attached to a collection of encoded transactions |
 
 ## Test Cases
 
@@ -92,3 +94,11 @@ A human-readable example of forming a transaction and signing it
 ### group transactions
 
 A collection of transactions can be grouped
+
+### encode transactions
+
+A collection of transactions can be encoded
+
+### encode transactions with signatures
+
+Signatures can be attached to a collection of encoded transactions

--- a/packages/python/algokit_transact/pyproject.toml
+++ b/packages/python/algokit_transact/pyproject.toml
@@ -24,7 +24,11 @@ module-name = "_algokit_transact"
 include = ["algokit_transact/py.typed", "algokit_transact/__init__.py"]
 
 [tool.pytest.ini_options]
-markers = ["group_generic_transaction_tests", "group_transaction_tests"]
+markers = [
+  "group_generic_transaction_tests",
+  "group_transaction_tests",
+  "group_transaction_group_tests",
+]
 
 [tool.poetry.group.dev.dependencies]
 maturin = [

--- a/packages/python/algokit_transact/tests/test_transaction_group.py
+++ b/packages/python/algokit_transact/tests/test_transaction_group.py
@@ -5,8 +5,9 @@ from algokit_transact import (
     group_transactions,
     encode_transaction,
     encode_transactions,
-    attach_signature,
-    attach_signatures,
+    encode_signed_transaction,
+    encode_signed_transactions,
+    SignedTransaction,
 )
 
 simple_payment = TEST_DATA.simple_payment
@@ -109,10 +110,22 @@ def test_encode_transactions_with_signatures():
         ).signature,
     ]
 
-    encoded_signed_grouped_txs = attach_signatures(encoded_grouped_txs, tx_signatures)
+    # Create SignedTransaction objects from grouped transactions and signatures
+    signed_grouped_txs = [
+        SignedTransaction(
+            transaction=grouped_txs[i],
+            signature=tx_signatures[i],
+        )
+        for i in range(len(grouped_txs))
+    ]
+
+    encoded_signed_grouped_txs = encode_signed_transactions(signed_grouped_txs)
 
     assert len(encoded_signed_grouped_txs) == len(txs)
     for i in range(len(encoded_signed_grouped_txs)):
-        assert encoded_signed_grouped_txs[i] == attach_signature(
-            encoded_grouped_txs[i], tx_signatures[i]
+        assert encoded_signed_grouped_txs[i] == encode_signed_transaction(
+            SignedTransaction(
+                transaction=grouped_txs[i],
+                signature=tx_signatures[i],
+            )
         )

--- a/packages/python/algokit_transact/tests/test_transaction_group.py
+++ b/packages/python/algokit_transact/tests/test_transaction_group.py
@@ -1,19 +1,20 @@
 import pytest
 
 from . import TEST_DATA
-from algokit_transact import group_transactions
+from algokit_transact import (
+    group_transactions,
+    encode_transaction,
+    encode_transactions,
+    attach_signature,
+    attach_signatures,
+)
 
 simple_payment = TEST_DATA.simple_payment
 opt_in_asset_transfer = TEST_DATA.opt_in_asset_transfer
 
-# Polytest Suite: Transaction Group
 
-# Polytest Group: Transaction Group Tests
-
-
-@pytest.mark.group_transaction_group_tests
-def test_group_transactions():
-    """A collection of transactions can be grouped"""
+def simple_group():
+    """Helper function to create a simple transaction group"""
     expected_group_id = bytes(
         [
             202,
@@ -50,12 +51,68 @@ def test_group_transactions():
             49,
         ]
     )
-
     txs = [simple_payment.transaction, opt_in_asset_transfer.transaction]
+
+    return {
+        "txs": txs,
+        "expected_group_id": expected_group_id,
+    }
+
+
+# Polytest Suite: Transaction Group
+
+# Polytest Group: Transaction Group Tests
+
+
+@pytest.mark.group_transaction_group_tests
+def test_group_transactions():
+    """A collection of transactions can be grouped"""
+    data = simple_group()
+    txs = data["txs"]
+    expected_group_id = data["expected_group_id"]
+
     grouped_txs = group_transactions(txs)
 
     assert len(grouped_txs) == len(txs)
-
     for i in range(len(txs)):
         assert txs[i].group is None
         assert grouped_txs[i].group == expected_group_id
+
+
+@pytest.mark.group_transaction_group_tests
+def test_encode_transactions():
+    """A collection of transactions can be encoded"""
+    data = simple_group()
+    txs = data["txs"]
+    grouped_txs = group_transactions(txs)
+
+    encoded_grouped_txs = encode_transactions(grouped_txs)
+
+    assert len(encoded_grouped_txs) == len(txs)
+    for i in range(len(encoded_grouped_txs)):
+        assert encoded_grouped_txs[i] == encode_transaction(grouped_txs[i])
+
+
+@pytest.mark.group_transaction_group_tests
+def test_encode_transactions_with_signatures():
+    """Signatures can be attached to a collection of encoded transactions"""
+    data = simple_group()
+    txs = data["txs"]
+    grouped_txs = group_transactions(txs)
+    encoded_grouped_txs = encode_transactions(grouped_txs)
+
+    # Create signatures for each transaction
+    tx_signatures = [
+        simple_payment.signing_private_key.sign(encoded_grouped_txs[0]).signature,
+        opt_in_asset_transfer.signing_private_key.sign(
+            encoded_grouped_txs[1]
+        ).signature,
+    ]
+
+    encoded_signed_grouped_txs = attach_signatures(encoded_grouped_txs, tx_signatures)
+
+    assert len(encoded_signed_grouped_txs) == len(txs)
+    for i in range(len(encoded_signed_grouped_txs)):
+        assert encoded_signed_grouped_txs[i] == attach_signature(
+            encoded_grouped_txs[i], tx_signatures[i]
+        )

--- a/packages/python/algokit_transact/tests/test_transaction_group.py
+++ b/packages/python/algokit_transact/tests/test_transaction_group.py
@@ -7,6 +7,8 @@ from algokit_transact import (
     encode_transactions,
     encode_signed_transaction,
     encode_signed_transactions,
+    decode_transactions,
+    decode_signed_transactions,
     SignedTransaction,
 )
 
@@ -93,10 +95,13 @@ def test_encode_transactions():
     for i in range(len(encoded_grouped_txs)):
         assert encoded_grouped_txs[i] == encode_transaction(grouped_txs[i])
 
+    decoded_grouped_txs = decode_transactions(encoded_grouped_txs)
+    assert decoded_grouped_txs == grouped_txs
+
 
 @pytest.mark.group_transaction_group_tests
-def test_encode_transactions_with_signatures():
-    """Signatures can be attached to a collection of encoded transactions"""
+def test_encode_signed_transactions():
+    """A collection of signed transactions can be encoded"""
     data = simple_group()
     txs = data["txs"]
     grouped_txs = group_transactions(txs)
@@ -129,3 +134,6 @@ def test_encode_transactions_with_signatures():
                 signature=tx_signatures[i],
             )
         )
+
+    decoded_signed_grouped_txs = decode_signed_transactions(encoded_signed_grouped_txs)
+    assert decoded_signed_grouped_txs == signed_grouped_txs

--- a/packages/typescript/algokit_transact/__tests__/transaction_group.test.ts
+++ b/packages/typescript/algokit_transact/__tests__/transaction_group.test.ts
@@ -1,9 +1,23 @@
 import { expect, test, describe } from "bun:test";
 import { testData } from "./common.ts";
-import { groupTransactions } from "..";
+import { attachSignature, attachSignatures, encodeTransaction, encodeTransactions, groupTransactions } from "..";
+import * as ed from "@noble/ed25519";
 
 const simplePayment = testData.simplePayment;
 const optInAssetTransfer = testData.optInAssetTransfer;
+
+const simpleGroup = () => {
+  const expectedGroupId = Uint8Array.from([
+    202, 79, 82, 7, 197, 237, 213, 55, 117, 226, 131, 74, 221, 85, 86, 215, 64, 133, 212, 7, 58, 234, 248, 162, 222, 53, 161, 29, 141, 101,
+    133, 49,
+  ]);
+  const txs = [simplePayment.transaction, optInAssetTransfer.transaction];
+
+  return {
+    txs,
+    expectedGroupId,
+  };
+};
 
 describe("Transaction Group", () => {
   // Polytest Suite: Transaction Group
@@ -12,17 +26,43 @@ describe("Transaction Group", () => {
     // Polytest Group: Transaction Group Tests
 
     test("group transactions", () => {
-      const expectedGroupId = Uint8Array.from([
-        202, 79, 82, 7, 197, 237, 213, 55, 117, 226, 131, 74, 221, 85, 86, 215, 64, 133, 212, 7, 58, 234, 248, 162, 222, 53, 161, 29, 141,
-        101, 133, 49,
-      ]);
-      const txs = [simplePayment.transaction, optInAssetTransfer.transaction];
+      const { txs, expectedGroupId } = simpleGroup();
+
       const groupedTxs = groupTransactions(txs);
 
       expect(groupedTxs.length).toBe(txs.length);
       for (let i = 0; i < txs.length; i++) {
         expect(txs[i].group).toBeUndefined();
         expect(groupedTxs[i].group).toEqual(expectedGroupId);
+      }
+    });
+
+    test("encode transactions", () => {
+      const { txs } = simpleGroup();
+      const groupedTxs = groupTransactions(txs);
+
+      const encodedGroupedTxs = encodeTransactions(groupedTxs);
+
+      expect(encodedGroupedTxs.length).toBe(txs.length);
+      for (let i = 0; i < encodedGroupedTxs.length; i++) {
+        expect(encodedGroupedTxs[i]).toEqual(encodeTransaction(groupedTxs[i]));
+      }
+    });
+
+    test("encode transactions with signatures", async () => {
+      const { txs } = simpleGroup();
+      const groupedTxs = groupTransactions(txs);
+      const encodedGroupedTxs = encodeTransactions(groupedTxs);
+      const txSignatures = [
+        await ed.signAsync(encodedGroupedTxs[0], simplePayment.signingPrivateKey),
+        await ed.signAsync(encodedGroupedTxs[1], optInAssetTransfer.signingPrivateKey),
+      ];
+
+      const encodedSignedGroupedTxs = attachSignatures(encodedGroupedTxs, txSignatures);
+
+      expect(encodedSignedGroupedTxs.length).toBe(txs.length);
+      for (let i = 0; i < encodedSignedGroupedTxs.length; i++) {
+        expect(encodedSignedGroupedTxs[i]).toEqual(attachSignature(encodedGroupedTxs[i], txSignatures[i]));
       }
     });
   });

--- a/packages/typescript/algokit_transact/__tests__/transaction_group.test.ts
+++ b/packages/typescript/algokit_transact/__tests__/transaction_group.test.ts
@@ -1,7 +1,8 @@
 import { expect, test, describe } from "bun:test";
 import { testData } from "./common.ts";
-import { encodeSignedTransaction, encodeSignedTransactions, encodeTransaction, encodeTransactions, groupTransactions, SignedTransaction } from "..";
+import { decodeSignedTransactions, decodeTransactions, encodeSignedTransaction, encodeSignedTransactions, encodeTransaction, encodeTransactions, groupTransactions, SignedTransaction } from "..";
 import * as ed from "@noble/ed25519";
+import { decode } from "punycode";
 
 const simplePayment = testData.simplePayment;
 const optInAssetTransfer = testData.optInAssetTransfer;
@@ -47,9 +48,12 @@ describe("Transaction Group", () => {
       for (let i = 0; i < encodedGroupedTxs.length; i++) {
         expect(encodedGroupedTxs[i]).toEqual(encodeTransaction(groupedTxs[i]));
       }
+
+      const decodedGroupedTxs = decodeTransactions(encodedGroupedTxs);
+      expect(decodedGroupedTxs).toEqual(groupedTxs);
     });
 
-    test("encode transactions with signatures", async () => {
+    test("encode signed transactions", async () => {
       const { txs } = simpleGroup();
       const groupedTxs = groupTransactions(txs);
       const encodedGroupedTxs = encodeTransactions(groupedTxs);
@@ -74,6 +78,9 @@ describe("Transaction Group", () => {
           signature: txSignatures[i],
         }));
       }
+
+      const decodedSignedGroupedTxs = decodeSignedTransactions(encodedSignedGroupedTxs);
+      expect(decodedSignedGroupedTxs).toEqual(signedGroupedTxs);
     });
   });
 });

--- a/packages/typescript/algokit_transact/__tests__/transaction_group.test.ts
+++ b/packages/typescript/algokit_transact/__tests__/transaction_group.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe } from "bun:test";
 import { testData } from "./common.ts";
-import { attachSignature, attachSignatures, encodeTransaction, encodeTransactions, groupTransactions } from "..";
+import { encodeSignedTransaction, encodeSignedTransactions, encodeTransaction, encodeTransactions, groupTransactions, SignedTransaction } from "..";
 import * as ed from "@noble/ed25519";
 
 const simplePayment = testData.simplePayment;
@@ -58,11 +58,21 @@ describe("Transaction Group", () => {
         await ed.signAsync(encodedGroupedTxs[1], optInAssetTransfer.signingPrivateKey),
       ];
 
-      const encodedSignedGroupedTxs = attachSignatures(encodedGroupedTxs, txSignatures);
+      const signedGroupedTxs = groupedTxs.map((tx, i) => {
+        return {
+          transaction: tx,
+          signature: txSignatures[i],
+        } as SignedTransaction;
+      })
+
+      const encodedSignedGroupedTxs = encodeSignedTransactions(signedGroupedTxs);
 
       expect(encodedSignedGroupedTxs.length).toBe(txs.length);
       for (let i = 0; i < encodedSignedGroupedTxs.length; i++) {
-        expect(encodedSignedGroupedTxs[i]).toEqual(attachSignature(encodedGroupedTxs[i], txSignatures[i]));
+        expect(encodedSignedGroupedTxs[i]).toEqual(encodeSignedTransaction({
+          transaction: groupedTxs[i],
+          signature: txSignatures[i],
+        }));
       }
     });
   });


### PR DESCRIPTION
More generically this supports a collection of transactions, so can be used with grouped or ungrouped collections of transactions.

Depends on #104 