### PR TITLE
fix(typescript/algokit_transact): use node & esm bundles for main & module

### DIFF
--- a/packages/typescript/algokit_transact/__tests__/common.ts
+++ b/packages/typescript/algokit_transact/__tests__/common.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { Transaction } from "../src";
+import { Transaction } from "..";
 
 const jsonString = await Bun.file(path.join(__dirname, "../../../../crates/algokit_transact_ffi/test_data.json")).text();
 

--- a/packages/typescript/algokit_transact/__tests__/generic_transaction.test.ts
+++ b/packages/typescript/algokit_transact/__tests__/generic_transaction.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe } from "bun:test";
 import { testData } from "./common.ts";
-import { decodeTransaction } from "../src";
+import { decodeTransaction } from "..";
 
 describe("Generic Transaction", () => {
   // Polytest Suite: Generic Transaction

--- a/packages/typescript/algokit_transact/__tests__/payment.test.ts
+++ b/packages/typescript/algokit_transact/__tests__/payment.test.ts
@@ -12,7 +12,7 @@ import {
   getTransactionIdRaw,
   getTransactionId,
   assignFee,
-} from "../src/index";
+} from "..";
 
 const simplePayment = testData.simplePayment;
 

--- a/packages/typescript/algokit_transact/bunfig.toml
+++ b/packages/typescript/algokit_transact/bunfig.toml
@@ -1,2 +1,0 @@
-[test]
-preload = ["./src/bun.setup.ts"]

--- a/packages/typescript/algokit_transact/package.json
+++ b/packages/typescript/algokit_transact/package.json
@@ -5,8 +5,8 @@
   "files": [
     "dist/**/*"
   ],
-  "main": "./dist/algokit_transact.wasm2js.mjs",
-  "module": "./dist/algokit_transact.wasm2js.mjs",
+  "main": "./dist/algokit_transact.node.mjs",
+  "module": "./dist/algokit_transact.bundler.mjs",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/typescript/algokit_transact/src/bun.setup.ts
+++ b/packages/typescript/algokit_transact/src/bun.setup.ts
@@ -1,6 +1,0 @@
-import * as fs from "fs";
-import { initSync } from "../pkg/algokit_transact_ffi";
-
-const wasmBuffer = fs.readFileSync("pkg/algokit_transact_ffi_bg.wasm");
-const wasmModule = new WebAssembly.Module(wasmBuffer);
-initSync({ module: wasmModule });


### PR DESCRIPTION
Initially the main and module of the package.json was set to wasm2js under the assumption that only outdated software that didn't support wasm would be using those fields over exports. This was an incorrect assumption. This commit updates main & module to use the proper WASM bundles but the wasm2js bundle is still defined under exports for react-native