### PR TITLE
ci: add check_rust job to CI/CD

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -9,6 +9,24 @@ on:
       - main
 
 jobs:
+  check_rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.85.0
+      - name: Check formatting
+        run: cargo fmt --check
+      - name: Clippy
+        run: cargo clippy
+      - name: Check
+        run: cargo check
+      - name: Check WASM
+        run: cargo check --no-default-features --features ffi_wasm
+
   # A setup job to define the matricies that will be used across all of the jobs in this workflow
   setup:
     runs-on: ubuntu-latest

--- a/crates/algokit_transact/src/msgpack/mod.rs
+++ b/crates/algokit_transact/src/msgpack/mod.rs
@@ -371,24 +371,3 @@ mod tests {
         assert!(nested_str.find("\"x\"").unwrap() < nested_str.find("\"y\"").unwrap());
     }
 }
-
-// Allow users to use the standard `str::parse()` style API as well.
-impl std::str::FromStr for ModelType {
-    type Err = ();
-
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        ModelType::from_str(s).ok_or(())
-    }
-}
-
-// Provide a blanket implementation so every `Serialize` type automatically
-// gets the `ToMsgPack` methods.
-impl<T> ToMsgPack for T where T: Serialize {}
-
-// Implement `Display` for `ModelType` so it can be printed directly and used in
-// other error types if needed.
-impl std::fmt::Display for ModelType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
-}

--- a/crates/algokit_transact/src/test_utils/mod.rs
+++ b/crates/algokit_transact/src/test_utils/mod.rs
@@ -289,7 +289,7 @@ fn normalise_json(value: serde_json::Value) -> serde_json::Value {
                 .collect(),
         ),
         serde_json::Value::Array(arr) => {
-            serde_json::Value::Array(arr.into_iter().map(|v| normalise_json(v)).collect())
+            serde_json::Value::Array(arr.into_iter().map(normalise_json).collect())
         }
         other => other,
     }

--- a/crates/algokit_transact/src/traits.rs
+++ b/crates/algokit_transact/src/traits.rs
@@ -69,12 +69,12 @@ pub trait AlgorandMsgpack: Serialize + for<'de> Deserialize<'de> {
 
         // If there is a PREFIX defined, bytes is longer than the prefix, and the bytes start
         // with the prefix, decode the bytes without the prefix
-        if Self::PREFIX.len() > 0
+        if !Self::PREFIX.is_empty()
             && bytes.len() > Self::PREFIX.len()
             && &bytes[..Self::PREFIX.len()] == Self::PREFIX
         {
             let without_prefix = &bytes[Self::PREFIX.len()..];
-            Ok(rmp_serde::from_slice(&without_prefix)?)
+            Ok(rmp_serde::from_slice(without_prefix)?)
         } else {
             Ok(rmp_serde::from_slice(bytes)?)
         }

--- a/crates/algokit_transact/src/transactions/mod.rs
+++ b/crates/algokit_transact/src/transactions/mod.rs
@@ -100,19 +100,19 @@ impl Transaction {
         let header = tx.header_mut();
         header.fee = Some(calculated_fee);
 
-        return Ok(tx);
+        Ok(tx)
     }
 }
 
 impl PaymentTransactionBuilder {
     pub fn build(&self) -> Result<Transaction, PaymentTransactionBuilderError> {
-        self.build_fields().map(|d| Transaction::Payment(d))
+        self.build_fields().map(Transaction::Payment)
     }
 }
 
 impl AssetTransferTransactionBuilder {
     pub fn build(&self) -> Result<Transaction, AssetTransferTransactionBuilderError> {
-        self.build_fields().map(|d| Transaction::AssetTransfer(d))
+        self.build_fields().map(Transaction::AssetTransfer)
     }
 }
 
@@ -123,7 +123,7 @@ impl TransactionId for Transaction {}
 
 impl EstimateTransactionSize for Transaction {
     fn estimate_size(&self) -> Result<usize, AlgoKitTransactError> {
-        return Ok(self.encode_raw()?.len() + ALGORAND_SIGNATURE_ENCODING_INCR);
+        Ok(self.encode_raw()?.len() + ALGORAND_SIGNATURE_ENCODING_INCR)
     }
 }
 
@@ -171,17 +171,17 @@ impl AlgorandMsgpack for SignedTransaction {
                     .1;
 
                 let mut txn_buf = Vec::new();
-                rmpv::encode::write_value(&mut txn_buf, &txn_value)?;
+                rmpv::encode::write_value(&mut txn_buf, txn_value)?;
 
                 let stxn = SignedTransaction {
                     transaction: Transaction::decode(&txn_buf)?,
                     ..rmp_serde::from_slice(bytes)?
                 };
 
-                return Ok(stxn);
+                Ok(stxn)
             }
             _ => {
-                return Err(AlgoKitTransactError::InputError(format!(
+                Err(AlgoKitTransactError::InputError(format!(
                     "expected signed transaction to be a map, but got a: {:#?}",
                     value.type_id()
                 )))
@@ -201,7 +201,7 @@ impl TransactionId for SignedTransaction {
 
 impl EstimateTransactionSize for SignedTransaction {
     fn estimate_size(&self) -> Result<usize, AlgoKitTransactError> {
-        return Ok(self.encode()?.len());
+        Ok(self.encode()?.len())
     }
 }
 

--- a/crates/algokit_transact/src/transactions/mod.rs
+++ b/crates/algokit_transact/src/transactions/mod.rs
@@ -180,12 +180,10 @@ impl AlgorandMsgpack for SignedTransaction {
 
                 Ok(stxn)
             }
-            _ => {
-                Err(AlgoKitTransactError::InputError(format!(
-                    "expected signed transaction to be a map, but got a: {:#?}",
-                    value.type_id()
-                )))
-            }
+            _ => Err(AlgoKitTransactError::InputError(format!(
+                "expected signed transaction to be a map, but got a: {:#?}",
+                value.type_id()
+            ))),
         }
     }
 }

--- a/crates/algokit_transact/src/utils.rs
+++ b/crates/algokit_transact/src/utils.rs
@@ -42,7 +42,7 @@ pub fn is_zero(n: &u64) -> bool {
 }
 
 pub fn is_zero_opt(n: &Option<u64>) -> bool {
-    n.as_ref().map_or(true, is_zero)
+    n.as_ref().is_none_or(is_zero)
 }
 
 pub fn is_zero_addr(addr: &Address) -> bool {
@@ -50,7 +50,7 @@ pub fn is_zero_addr(addr: &Address) -> bool {
 }
 
 pub fn is_zero_addr_opt(addr: &Option<Address>) -> bool {
-    addr.as_ref().map_or(true, is_zero_addr)
+    addr.as_ref().is_none_or(is_zero_addr)
 }
 
 pub fn is_empty_bytes32(bytes: &Byte32) -> bool {
@@ -58,20 +58,20 @@ pub fn is_empty_bytes32(bytes: &Byte32) -> bool {
 }
 
 pub fn is_empty_bytes32_opt(bytes: &Option<Byte32>) -> bool {
-    bytes.as_ref().map_or(true, is_empty_bytes32)
+    bytes.as_ref().is_none_or(is_empty_bytes32)
 }
 
 pub fn is_empty_string_opt(string: &Option<String>) -> bool {
-    string.as_ref().map_or(true, String::is_empty)
+    string.as_ref().is_none_or(String::is_empty)
 }
 
 pub fn is_empty_vec_opt<T>(vec: &Option<Vec<T>>) -> bool {
-    vec.as_ref().map_or(true, Vec::is_empty)
+    vec.as_ref().is_none_or(Vec::is_empty)
 }
 
 pub fn pub_key_to_checksum(pub_key: &Byte32) -> [u8; ALGORAND_CHECKSUM_BYTE_LENGTH] {
     let mut hasher = Sha512_256::new();
-    hasher.update(&pub_key);
+    hasher.update(pub_key);
 
     let mut checksum = [0u8; ALGORAND_CHECKSUM_BYTE_LENGTH];
     checksum
@@ -81,7 +81,7 @@ pub fn pub_key_to_checksum(pub_key: &Byte32) -> [u8; ALGORAND_CHECKSUM_BYTE_LENG
 
 pub fn hash(bytes: &Vec<u8>) -> Byte32 {
     let mut hasher = Sha512_256::new();
-    hasher.update(&bytes);
+    hasher.update(bytes);
 
     let mut group = [0u8; HASH_BYTES_LENGTH];
     group.copy_from_slice(&hasher.finalize()[..HASH_BYTES_LENGTH]);

--- a/crates/algokit_transact_ffi/src/lib.rs
+++ b/crates/algokit_transact_ffi/src/lib.rs
@@ -6,7 +6,9 @@ use algokit_transact::msgpack::{
     encode_json_to_msgpack as internal_encode_json_to_msgpack,
     AlgoKitMsgPackError as InternalMsgPackError, ModelType as InternalModelType,
 };
-use algokit_transact::{AlgorandMsgpack, Byte32, EstimateTransactionSize, TransactionId, Transactions};
+use algokit_transact::{
+    AlgorandMsgpack, Byte32, EstimateTransactionSize, TransactionId, Transactions,
+};
 use ffi_macros::{ffi_enum, ffi_func, ffi_record};
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
@@ -254,11 +256,9 @@ impl TryFrom<Transaction> for algokit_transact::Transaction {
             TransactionType::AssetTransfer => {
                 Ok(algokit_transact::Transaction::AssetTransfer(tx.try_into()?))
             }
-            _ => {
-                Err(Self::Error::DecodingError(
-                    "Transaction type is not implemented".to_string(),
-                ))
-            }
+            _ => Err(Self::Error::DecodingError(
+                "Transaction type is not implemented".to_string(),
+            )),
         }
     }
 }

--- a/crates/algokit_transact_ffi/src/lib.rs
+++ b/crates/algokit_transact_ffi/src/lib.rs
@@ -143,10 +143,10 @@ pub struct Address {
 
 impl From<algokit_transact::Address> for Address {
     fn from(value: algokit_transact::Address) -> Self {
-        return Self {
+        Self {
             address: value.to_string(),
             pub_key: value.pub_key.to_vec().into(),
-        };
+        }
     }
 }
 
@@ -255,9 +255,9 @@ impl TryFrom<Transaction> for algokit_transact::Transaction {
                 Ok(algokit_transact::Transaction::AssetTransfer(tx.try_into()?))
             }
             _ => {
-                return Err(Self::Error::DecodingError(
+                Err(Self::Error::DecodingError(
                     "Transaction type is not implemented".to_string(),
-                ));
+                ))
             }
         }
     }
@@ -528,7 +528,7 @@ pub fn encode_transaction_raw(tx: Transaction) -> Result<Vec<u8>, AlgoKitTransac
 #[ffi_func]
 pub fn decode_transaction(encoded_tx: &[u8]) -> Result<Transaction, AlgoKitTransactError> {
     let ctx: algokit_transact::Transaction = algokit_transact::Transaction::decode(encoded_tx)?;
-    Ok(ctx.try_into()?)
+    ctx.try_into()
 }
 
 /// Decodes a collection of MsgPack bytes into a transaction collection.
@@ -572,7 +572,7 @@ pub fn decode_transactions(
 #[ffi_func]
 pub fn estimate_transaction_size(transaction: Transaction) -> Result<u64, AlgoKitTransactError> {
     let core_tx: algokit_transact::Transaction = transaction.try_into()?;
-    return core_tx
+    core_tx
         .estimate_size()
         .map_err(|e| {
             AlgoKitTransactError::EncodingError(format!(
@@ -583,7 +583,7 @@ pub fn estimate_transaction_size(transaction: Transaction) -> Result<u64, AlgoKi
         .try_into()
         .map_err(|_| {
             AlgoKitTransactError::EncodingError("Failed to convert size to u64".to_string())
-        });
+        })
 }
 
 #[ffi_func]
@@ -716,7 +716,7 @@ pub fn assign_fee(
 
     let updated_txn = txn_internal.assign_fee(fee_params_internal)?;
 
-    Ok(updated_txn.try_into()?)
+    updated_txn.try_into()
 }
 
 /// Decodes a signed transaction.

--- a/docs/src/main.rs
+++ b/docs/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Then generate API documentation to a temporary location to move to the docs directory
     println!("Generating API documentation...");
     let cargo_doc = Command::new("cargo")
-        .args(&[
+        .args([
             "doc",
             "-p",
             "algokit_transact",
@@ -46,7 +46,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if api_source.exists() {
         println!("Copying API documentation...");
-        copy_dir_all(api_source, &api_target)?;
+        copy_dir_all(api_source, api_target)?;
 
         // Clean up temporary directory
         let _ = fs::remove_dir_all("target/temp_cargo");

--- a/tools/build_pkgs/src/python.rs
+++ b/tools/build_pkgs/src/python.rs
@@ -2,8 +2,8 @@ use crate::{Package, get_repo_root, run};
 use color_eyre::eyre::{Result, eyre};
 
 pub fn build(package: &Package) -> Result<()> {
-    let crate_name = package.crate_name();
-    let ext = if cfg!(target_os = "windows") {
+    let _crate_name = package.crate_name();
+    let _ext = if cfg!(target_os = "windows") {
         "dll"
     } else if cfg!(target_os = "macos") {
         "dylib"
@@ -48,7 +48,7 @@ pub fn build(package: &Package) -> Result<()> {
     if cfg!(target_os = "linux") {
         let dist_files: Vec<_> = std::fs::read_dir(package_dir.join("dist"))?
             .filter_map(Result::ok)
-            .filter(|entry| entry.path().extension().map_or(false, |ext| ext == "whl"))
+            .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "whl"))
             .collect();
 
         if dist_files.is_empty() {

--- a/tools/build_pkgs/src/typescript.rs
+++ b/tools/build_pkgs/src/typescript.rs
@@ -48,16 +48,16 @@ fn wasm_pack(package: &Package, target: &WasmPackTarget, dir: &Path) -> Result<O
 fn pack_and_bundle(package: &Package, mode: &WasmPackMode, dir: &Path) -> Result<Output> {
     run("bun install", Some(dir), None)?;
     match mode {
-        WasmPackMode::Esm => wasm_pack(&package, &WasmPackTarget::Web, dir),
-        WasmPackMode::Cjs => wasm_pack(&package, &WasmPackTarget::Web, dir),
+        WasmPackMode::Esm => wasm_pack(package, &WasmPackTarget::Web, dir),
+        WasmPackMode::Cjs => wasm_pack(package, &WasmPackTarget::Web, dir),
         WasmPackMode::Wasm2js => {
-            let output = wasm_pack(&package, &WasmPackTarget::Bundler, dir)?;
+            let output = wasm_pack(package, &WasmPackTarget::Bundler, dir)?;
 
             run(
                 &format!(
                     "bunx wasm2js -O pkg/{package}_ffi_bg.wasm -o pkg/{package}_ffi_bg.wasm.js",
                 ),
-                Some(&dir),
+                Some(dir),
                 None,
             )?;
 

--- a/tools/cargo-bin/src/main.rs
+++ b/tools/cargo-bin/src/main.rs
@@ -6,7 +6,7 @@ fn main() {
     // Only reached if run-bin code fails, otherwise process exits early from within
     // binary::run.
     if let Err(res) = res {
-        eprintln!("\x1b[31m{}\x1b[0m", format!("run-bin failed: {res}"));
+        eprintln!("\x1b[31mrun-bin failed: {res}\x1b[0m");
         process::exit(1);
     }
 }


### PR DESCRIPTION
Runs `cargo check`, `cargo clippy`, and `cargo fmt --check` on the entire workspace. 

Clippy is not necessary, but certain helps write cleaner more idiomatic Rust code