### PR TITLE
Composer tweaks

### DIFF
--- a/crates/algokit_utils/src/lib.rs
+++ b/crates/algokit_utils/src/lib.rs
@@ -13,7 +13,7 @@ pub use testing::{
 pub use transactions::{
     AccountCloseParams, ApplicationCallParams, ApplicationCreateParams, ApplicationDeleteParams,
     ApplicationUpdateParams, AssetCreateParams, AssetDestroyParams, AssetReconfigureParams,
-    CommonParams, Composer, ComposerError, ComposerTxn, EmptySigner,
+    CommonParams, Composer, ComposerError, ComposerTransaction, EmptySigner,
     NonParticipationKeyRegistrationParams, OfflineKeyRegistrationParams,
-    OnlineKeyRegistrationParams, PaymentParams, TxnSigner, TxnSignerGetter,
+    OnlineKeyRegistrationParams, PaymentParams, TransactionSigner, TransactionSignerGetter,
 };

--- a/crates/algokit_utils/src/testing/fixture.rs
+++ b/crates/algokit_utils/src/testing/fixture.rs
@@ -1,15 +1,15 @@
 use std::sync::Arc;
 
 use super::account_helpers::{NetworkType, TestAccount, TestAccountConfig, TestAccountManager};
-use crate::{AlgoConfig, ClientManager, Composer, TxnSigner, TxnSignerGetter};
+use crate::{AlgoConfig, ClientManager, Composer, TransactionSigner, TransactionSignerGetter};
 use algod_client::AlgodClient;
 use algokit_transact::{Address, AlgorandMsgpack, SignedTransaction, Transaction};
 use async_trait::async_trait;
 
-// Implement TxnSigner for TestAccount directly, eliminating the need for TestAccountSigner wrapper
+// Implement TransactionSigner for TestAccount directly, eliminating the need for TestAccountSigner wrapper
 #[async_trait]
-impl TxnSigner for TestAccount {
-    async fn sign_txns(
+impl TransactionSigner for TestAccount {
+    async fn sign_transactions(
         &self,
         txns: &[Transaction],
         indices: &[usize],
@@ -34,10 +34,10 @@ impl TxnSigner for TestAccount {
     }
 }
 
-// Implement TxnSignerGetter for TestAccount as well
+// Implement TransactionSignerGetter for TestAccount as well
 #[async_trait]
-impl TxnSignerGetter for TestAccount {
-    async fn get_signer(&self, address: Address) -> Option<&dyn TxnSigner> {
+impl TransactionSignerGetter for TestAccount {
+    async fn get_signer(&self, address: Address) -> Option<&dyn TransactionSigner> {
         let test_account_address = self.account().expect("Failed to get test account address");
         if address == test_account_address.address() {
             Some(self)
@@ -101,7 +101,7 @@ impl AlgorandFixture {
             .await
             .map_err(|e| format!("Failed to create test account: {}", e))?;
 
-        // Now TestAccount implements TxnSignerGetter directly, so we can use it without a wrapper
+        // Now TestAccount implements TransactionSignerGetter directly, so we can use it without a wrapper
         let composer = Composer::new(algod.clone(), Some(Arc::new(test_account.clone())));
 
         self.context = Some(AlgorandTestContext {

--- a/crates/algokit_utils/src/transactions/mod.rs
+++ b/crates/algokit_utils/src/transactions/mod.rs
@@ -11,8 +11,10 @@ pub use application_call::{
     ApplicationUpdateParams,
 };
 pub use asset_config::{AssetCreateParams, AssetDestroyParams, AssetReconfigureParams};
-pub use common::{CommonParams, DefaultSignerGetter, EmptySigner, TxnSigner, TxnSignerGetter};
-pub use composer::{Composer, ComposerError, ComposerTxn};
+pub use common::{
+    CommonParams, DefaultSignerGetter, EmptySigner, TransactionSigner, TransactionSignerGetter,
+};
+pub use composer::{Composer, ComposerError, ComposerTransaction};
 pub use key_registration::{
     NonParticipationKeyRegistrationParams, OfflineKeyRegistrationParams,
     OnlineKeyRegistrationParams,

--- a/crates/algokit_utils/tests/transactions/composer/application_call.rs
+++ b/crates/algokit_utils/tests/transactions/composer/application_call.rs
@@ -50,20 +50,21 @@ async fn test_application_call_transaction() {
         .expect("Failed to add application call");
 
     let result = composer
-        .send()
+        .send(None)
         .await
         .expect("Failed to send application call");
+    let confirmation = &result.confirmations[0];
 
     assert!(
-        result.confirmed_round.is_some(),
+        confirmation.confirmed_round.is_some(),
         "Transaction should be confirmed"
     );
     assert!(
-        result.confirmed_round.unwrap() > 0,
+        confirmation.confirmed_round.unwrap() > 0,
         "Confirmed round should be greater than 0"
     );
 
-    let transaction = result.txn.transaction;
+    let transaction = &confirmation.txn.transaction;
 
     match transaction {
         algokit_transact::Transaction::ApplicationCall(application_call_fields) => {
@@ -123,20 +124,21 @@ async fn test_application_create_transaction() {
         .expect("Failed to add application create");
 
     let result = composer
-        .send()
+        .send(None)
         .await
         .expect("Failed to send application create");
+    let confirmation = &result.confirmations[0];
 
     assert!(
-        result.confirmed_round.is_some(),
+        confirmation.confirmed_round.is_some(),
         "Transaction should be confirmed"
     );
     assert!(
-        result.confirmed_round.unwrap() > 0,
+        confirmation.confirmed_round.unwrap() > 0,
         "Confirmed round should be greater than 0"
     );
 
-    let transaction = result.txn.transaction;
+    let transaction = &confirmation.txn.transaction;
 
     match transaction {
         algokit_transact::Transaction::ApplicationCall(application_call_fields) => {
@@ -205,20 +207,21 @@ async fn test_application_delete_transaction() {
         .expect("Failed to add application delete");
 
     let result = composer
-        .send()
+        .send(None)
         .await
         .expect("Failed to send application delete");
+    let confirmation = &result.confirmations[0];
 
     assert!(
-        result.confirmed_round.is_some(),
+        confirmation.confirmed_round.is_some(),
         "Transaction should be confirmed"
     );
     assert!(
-        result.confirmed_round.unwrap() > 0,
+        confirmation.confirmed_round.unwrap() > 0,
         "Confirmed round should be greater than 0"
     );
 
-    let transaction = result.txn.transaction;
+    let transaction = &confirmation.txn.transaction;
 
     match transaction {
         algokit_transact::Transaction::ApplicationCall(application_call_fields) => {
@@ -279,20 +282,21 @@ async fn test_application_update_transaction() {
         .expect("Failed to add application update");
 
     let result = composer
-        .send()
+        .send(None)
         .await
         .expect("Failed to send application update");
 
+    let confirmation = &result.confirmations[0];
+
     assert!(
-        result.confirmed_round.is_some(),
+        confirmation.confirmed_round.is_some(),
         "Transaction should be confirmed"
     );
     assert!(
-        result.confirmed_round.unwrap() > 0,
+        confirmation.confirmed_round.unwrap() > 0,
         "Confirmed round should be greater than 0"
     );
-
-    let transaction = result.txn.transaction;
+    let transaction = &confirmation.txn.transaction;
 
     match transaction {
         algokit_transact::Transaction::ApplicationCall(application_call_fields) => {
@@ -359,9 +363,9 @@ async fn create_test_app(context: &AlgorandTestContext, sender: Address) -> Opti
         .expect("Failed to add application create");
 
     let result = composer
-        .send()
+        .send(None)
         .await
         .expect("Failed to send application create");
 
-    result.application_index
+    result.confirmations[0].application_index
 }

--- a/crates/algokit_utils/tests/transactions/composer/asset_config.rs
+++ b/crates/algokit_utils/tests/transactions/composer/asset_config.rs
@@ -45,19 +45,23 @@ async fn test_asset_create_transaction() {
         .add_asset_create(asset_create_params)
         .expect("Failed to add asset create");
 
-    let result = composer.send().await.expect("Failed to send asset create");
+    let result = composer
+        .send(None)
+        .await
+        .expect("Failed to send asset create");
+    let confirmation = &result.confirmations[0];
 
     // Assert transaction was confirmed
     assert!(
-        result.confirmed_round.is_some(),
+        confirmation.confirmed_round.is_some(),
         "Transaction should be confirmed"
     );
     assert!(
-        result.confirmed_round.unwrap() > 0,
+        confirmation.confirmed_round.unwrap() > 0,
         "Confirmed round should be greater than 0"
     );
 
-    let transaction = result.txn.transaction;
+    let transaction = &confirmation.txn.transaction;
 
     match transaction {
         algokit_transact::Transaction::AssetConfig(asset_config_fields) => {
@@ -142,8 +146,13 @@ async fn test_asset_reconfigure_transaction() {
         .add_asset_create(asset_create_params)
         .expect("Failed to add asset create");
 
-    let create_result = composer.send().await.expect("Failed to send asset create");
-    let asset_id = create_result.asset_index.expect("Failed to get asset ID");
+    let create_result = composer
+        .send(None)
+        .await
+        .expect("Failed to send asset create");
+    let asset_id = create_result.confirmations[0]
+        .asset_index
+        .expect("Failed to get asset ID");
 
     // Now reconfigure the asset
     let asset_reconfigure_params = AssetReconfigureParams {
@@ -164,21 +173,23 @@ async fn test_asset_reconfigure_transaction() {
         .expect("Failed to add asset reconfigure");
 
     let result = composer
-        .send()
+        .send(None)
         .await
         .expect("Failed to send asset reconfigure");
 
+    let confirmation = &result.confirmations[0];
+
     // Assert transaction was confirmed
     assert!(
-        result.confirmed_round.is_some(),
+        confirmation.confirmed_round.is_some(),
         "Transaction should be confirmed"
     );
     assert!(
-        result.confirmed_round.unwrap() > 0,
+        confirmation.confirmed_round.unwrap() > 0,
         "Confirmed round should be greater than 0"
     );
 
-    let transaction = result.txn.transaction;
+    let transaction = &confirmation.txn.transaction;
 
     match transaction {
         algokit_transact::Transaction::AssetConfig(asset_config_fields) => {
@@ -234,8 +245,13 @@ async fn test_asset_destroy_transaction() {
         .add_asset_create(asset_create_params)
         .expect("Failed to add asset create");
 
-    let create_result = composer.send().await.expect("Failed to send asset create");
-    let asset_id = create_result.asset_index.expect("Failed to get asset ID");
+    let create_result = composer
+        .send(None)
+        .await
+        .expect("Failed to send asset create");
+    let asset_id = create_result.confirmations[0]
+        .asset_index
+        .expect("Failed to get asset ID");
 
     // Now destroy the asset
     let asset_destroy_params = AssetDestroyParams {
@@ -251,15 +267,19 @@ async fn test_asset_destroy_transaction() {
         .add_asset_destroy(asset_destroy_params)
         .expect("Failed to add asset destroy");
 
-    let result = composer.send().await.expect("Failed to send asset destroy");
+    let result = composer
+        .send(None)
+        .await
+        .expect("Failed to send asset destroy");
+    let confirmation = &result.confirmations[0];
 
     // Assert transaction was confirmed
     assert!(
-        result.confirmed_round.is_some(),
+        confirmation.confirmed_round.is_some(),
         "Transaction should be confirmed"
     );
     assert!(
-        result.confirmed_round.unwrap() > 0,
+        confirmation.confirmed_round.unwrap() > 0,
         "Confirmed round should be greater than 0"
     );
 }

--- a/crates/algokit_utils/tests/transactions/composer/key_registration.rs
+++ b/crates/algokit_utils/tests/transactions/composer/key_registration.rs
@@ -39,21 +39,21 @@ async fn test_offline_key_registration_transaction() {
         .expect("Failed to add offline key registration");
 
     let result = composer
-        .send()
+        .send(None)
         .await
         .expect("Failed to send offline key registration");
-
+    let confirmation = &result.confirmations[0];
     // Assert transaction was confirmed
     assert!(
-        result.confirmed_round.is_some(),
+        confirmation.confirmed_round.is_some(),
         "Transaction should be confirmed"
     );
     assert!(
-        result.confirmed_round.unwrap() > 0,
+        confirmation.confirmed_round.unwrap() > 0,
         "Confirmed round should be greater than 0"
     );
 
-    let transaction = result.txn.transaction;
+    let transaction = &confirmation.txn.transaction;
 
     match transaction {
         algokit_transact::Transaction::KeyRegistration(key_reg_fields) => {
@@ -158,12 +158,12 @@ async fn test_non_participation_key_registration_transaction() {
         .expect("Failed to add online key registration");
 
     let online_result = composer
-        .send()
+        .send(None)
         .await
         .expect("Failed to send online key registration");
 
     assert!(
-        online_result.confirmed_round.is_some(),
+        online_result.confirmations[0].confirmed_round.is_some(),
         "Online transaction should be confirmed"
     );
 
@@ -193,21 +193,22 @@ async fn test_non_participation_key_registration_transaction() {
         .expect("Failed to add non participation key registration");
 
     let result = composer2
-        .send()
+        .send(None)
         .await
         .expect("Failed to send non participation key registration");
+    let confirmation = &result.confirmations[0];
 
     // Assert transaction was confirmed
     assert!(
-        result.confirmed_round.is_some(),
+        confirmation.confirmed_round.is_some(),
         "Transaction should be confirmed"
     );
     assert!(
-        result.confirmed_round.unwrap() > 0,
+        confirmation.confirmed_round.unwrap() > 0,
         "Confirmed round should be greater than 0"
     );
 
-    let transaction = result.txn.transaction;
+    let transaction = &confirmation.txn.transaction;
 
     match transaction {
         algokit_transact::Transaction::KeyRegistration(key_reg_fields) => {
@@ -274,7 +275,7 @@ async fn test_non_participation_key_registration_transaction() {
         .expect("Failed to add second online key registration");
 
     // This should fail because the account is permanently marked as non-participating
-    let online_again_result = composer3.send().await;
+    let online_again_result = composer3.send(None).await;
 
     assert!(
         online_again_result.is_err(),
@@ -363,21 +364,22 @@ async fn test_online_key_registration_transaction() {
 
     // Submit the transaction - should succeed with proper keys and voting rounds
     let result = composer
-        .send()
+        .send(None)
         .await
         .expect("Failed to send online key registration");
+    let confirmation = &result.confirmations[0];
 
     // Assert transaction was confirmed
     assert!(
-        result.confirmed_round.is_some(),
+        confirmation.confirmed_round.is_some(),
         "Transaction should be confirmed"
     );
     assert!(
-        result.confirmed_round.unwrap() > 0,
+        confirmation.confirmed_round.unwrap() > 0,
         "Confirmed round should be greater than 0"
     );
 
-    let transaction = result.txn.transaction;
+    let transaction = &confirmation.txn.transaction;
 
     match transaction {
         algokit_transact::Transaction::KeyRegistration(key_reg_fields) => {

--- a/crates/algokit_utils/tests/transactions/composer/mod.rs
+++ b/crates/algokit_utils/tests/transactions/composer/mod.rs
@@ -2,3 +2,4 @@ pub mod application_call;
 pub mod asset_config;
 pub mod key_registration;
 pub mod payment;
+pub mod transaction_group;

--- a/crates/algokit_utils/tests/transactions/composer/payment.rs
+++ b/crates/algokit_utils/tests/transactions/composer/payment.rs
@@ -41,8 +41,8 @@ async fn test_basic_payment_transaction() {
         .add_payment(payment_params)
         .expect("Failed to add payment");
 
-    let result = composer.send().await.expect("Failed to send payment");
-    let transaction = result.txn.transaction;
+    let result = composer.send(None).await.expect("Failed to send payment");
+    let transaction = &result.confirmations[0].txn.transaction;
 
     match transaction {
         algokit_transact::Transaction::Payment(payment_fields) => {
@@ -96,8 +96,11 @@ async fn test_basic_account_close_transaction() {
         .add_account_close(account_close_params)
         .expect("Failed to add account close");
 
-    let result = composer.send().await.expect("Failed to send account close");
-    let transaction = result.txn.transaction;
+    let result = composer
+        .send(None)
+        .await
+        .expect("Failed to send account close");
+    let transaction = result.confirmations[0].txn.transaction.clone();
 
     match transaction {
         algokit_transact::Transaction::Payment(payment_fields) => {

--- a/crates/algokit_utils/tests/transactions/composer/transaction_group.rs
+++ b/crates/algokit_utils/tests/transactions/composer/transaction_group.rs
@@ -1,0 +1,275 @@
+use algokit_transact::MAX_TX_GROUP_SIZE;
+use algokit_transact::test_utils::TransactionGroupMother;
+use algokit_utils::testing::*;
+use algokit_utils::{AssetCreateParams, CommonParams, PaymentParams};
+
+use crate::common::init_test_logging;
+
+#[tokio::test]
+async fn test_payment_and_asset_create_group() {
+    init_test_logging();
+
+    let mut fixture = algorand_fixture().await.expect("Failed to create fixture");
+
+    fixture
+        .new_scope()
+        .await
+        .expect("Failed to create new scope");
+
+    let receiver = fixture
+        .generate_account(None)
+        .await
+        .expect("Failed to create receiver");
+
+    let receiver_addr = receiver
+        .account()
+        .expect("Failed to get receiver account")
+        .address();
+
+    let context = fixture.context().expect("Failed to get context");
+    let sender_addr = context
+        .test_account
+        .account()
+        .expect("Failed to get sender account")
+        .address();
+
+    let payment_params = PaymentParams {
+        common_params: CommonParams {
+            sender: sender_addr.clone(),
+            ..Default::default()
+        },
+        receiver: receiver_addr,
+        amount: 1_000_000,
+    };
+
+    let asset_create_params = AssetCreateParams {
+        common_params: CommonParams {
+            sender: sender_addr.clone(),
+            ..Default::default()
+        },
+        total: 1_000_000,
+        decimals: Some(2),
+        default_frozen: Some(false),
+        asset_name: Some("Group Test Asset".to_string()),
+        unit_name: Some("GTA".to_string()),
+        url: Some("https://group-test.com".to_string()),
+        metadata_hash: None,
+        manager: Some(sender_addr.clone()),
+        reserve: Some(sender_addr.clone()),
+        freeze: Some(sender_addr.clone()),
+        clawback: Some(sender_addr),
+    };
+
+    let mut composer = context.composer.clone();
+    composer
+        .add_payment(payment_params)
+        .expect("Failed to add payment");
+
+    composer
+        .add_asset_create(asset_create_params)
+        .expect("Failed to add asset create");
+
+    let result = composer
+        .send(None)
+        .await
+        .expect("Failed to send transaction group");
+
+    // Verify group properties
+    assert_eq!(
+        result.transaction_ids.len(),
+        2,
+        "Should have 2 transaction IDs in the group"
+    );
+    assert_eq!(
+        result.confirmations.len(),
+        2,
+        "Should have 2 confirmations in the group"
+    );
+
+    let group_id = result.group_id;
+    assert!(group_id.is_some(), "Group ID should be set");
+
+    // Verify payment transaction
+    let payment_confirmation = &result.confirmations[0];
+    assert!(
+        payment_confirmation.confirmed_round.is_some(),
+        "Payment transaction should be confirmed"
+    );
+    assert!(
+        payment_confirmation.confirmed_round.unwrap() > 0,
+        "Payment confirmed round should be greater than 0"
+    );
+
+    match &payment_confirmation.txn.transaction {
+        algokit_transact::Transaction::Payment(payment_fields) => {
+            assert_eq!(
+                payment_fields.amount, 1_000_000,
+                "Payment amount should be 1,000,000 microALGOs"
+            );
+        }
+        _ => panic!("First transaction should be a payment transaction"),
+    }
+
+    // Verify asset creation transaction
+    let asset_confirmation = &result.confirmations[1];
+    assert!(
+        asset_confirmation.confirmed_round.is_some(),
+        "Asset creation transaction should be confirmed"
+    );
+    assert!(
+        asset_confirmation.confirmed_round.unwrap() > 0,
+        "Asset creation confirmed round should be greater than 0"
+    );
+
+    match &asset_confirmation.txn.transaction {
+        algokit_transact::Transaction::AssetConfig(asset_config_fields) => {
+            assert_eq!(
+                asset_config_fields.asset_id, 0,
+                "Asset ID should be 0 for creation"
+            );
+            assert_eq!(
+                asset_config_fields.total,
+                Some(1_000_000),
+                "Total should be 1,000,000"
+            );
+            assert_eq!(
+                asset_config_fields.decimals,
+                Some(2),
+                "Decimals should be 2"
+            );
+            assert_eq!(
+                asset_config_fields.asset_name,
+                Some("Group Test Asset".to_string()),
+                "Asset name should match"
+            );
+            assert_eq!(
+                asset_config_fields.unit_name,
+                Some("GTA".to_string()),
+                "Unit name should match"
+            );
+        }
+        _ => panic!("Second transaction should be an asset config transaction"),
+    }
+
+    // Verify that the asset was actually created
+    assert!(
+        asset_confirmation.asset_index.is_some(),
+        "Asset index should be present for successful asset creation"
+    );
+    assert!(
+        asset_confirmation.asset_index.unwrap() > 0,
+        "Asset index should be greater than 0"
+    );
+}
+
+#[tokio::test]
+async fn test_add_transactions_to_group_max_size() {
+    init_test_logging();
+
+    let mut fixture = algorand_fixture().await.expect("Failed to create fixture");
+
+    fixture
+        .new_scope()
+        .await
+        .expect("Failed to create new scope");
+
+    let receiver = fixture
+        .generate_account(None)
+        .await
+        .expect("Failed to create receiver");
+
+    let receiver_addr = receiver
+        .account()
+        .expect("Failed to get receiver account")
+        .address();
+
+    let context = fixture.context().expect("Failed to get context");
+
+    let sender_addr = context
+        .test_account
+        .account()
+        .expect("Failed to get sender account")
+        .address();
+
+    let mut composer = context.composer.clone();
+
+    for i in 0..MAX_TX_GROUP_SIZE - 2 {
+        let payment_params = PaymentParams {
+            common_params: CommonParams {
+                sender: sender_addr.clone(),
+                ..Default::default()
+            },
+            receiver: receiver_addr.clone(),
+            amount: i as u64,
+        };
+
+        composer
+            .add_payment(payment_params)
+            .expect("Failed to add payment");
+    }
+
+    let new_transactions = TransactionGroupMother::group_of(2);
+
+    composer
+        .add_transactions(new_transactions)
+        .expect("Failed to add transactions to composer");
+
+    assert!(composer.transactions().len() == MAX_TX_GROUP_SIZE);
+}
+
+#[tokio::test]
+async fn test_add_transactions_to_group_too_big() {
+    init_test_logging();
+
+    let mut fixture = algorand_fixture().await.expect("Failed to create fixture");
+
+    fixture
+        .new_scope()
+        .await
+        .expect("Failed to create new scope");
+
+    let receiver = fixture
+        .generate_account(None)
+        .await
+        .expect("Failed to create receiver");
+
+    let receiver_addr = receiver
+        .account()
+        .expect("Failed to get receiver account")
+        .address();
+
+    let context = fixture.context().expect("Failed to get context");
+
+    let sender_addr = context
+        .test_account
+        .account()
+        .expect("Failed to get sender account")
+        .address();
+
+    let mut composer = context.composer.clone();
+
+    for i in 0..MAX_TX_GROUP_SIZE - 2 {
+        let payment_params = PaymentParams {
+            common_params: CommonParams {
+                sender: sender_addr.clone(),
+                ..Default::default()
+            },
+            receiver: receiver_addr.clone(),
+            amount: i as u64,
+        };
+
+        composer
+            .add_payment(payment_params)
+            .expect("Failed to add payment");
+    }
+
+    let new_transactions = TransactionGroupMother::group_of(3);
+
+    let result = composer.add_transactions(new_transactions);
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("Transaction group size exceeds the max limit of")
+    );
+}


### PR DESCRIPTION
Fixes #

## Proposed Changes

- Rename “Txn” types to “Transaction”, for example “ComposerTxn”.
- Add an “add_transactions” method to the composer to support atomically adding a collection of transactions to the composer.
- composer.send returns a PendingTransactionResponse, which only contains the first transaction in the group. Instead it should return a result like utils-ts does.

Note: for composer.send, ABIResults won't be returned yet until we support ABI methods
