### PR TITLE
Fix custom signer for transaction

### DIFF
--- a/crates/algokit_utils/src/testing/fixture.rs
+++ b/crates/algokit_utils/src/testing/fixture.rs
@@ -1,51 +1,9 @@
 use std::sync::Arc;
 
 use super::account_helpers::{NetworkType, TestAccount, TestAccountConfig, TestAccountManager};
-use crate::{AlgoConfig, ClientManager, Composer, TransactionSigner, TransactionSignerGetter};
+use crate::{AlgoConfig, ClientManager, Composer};
 use algod_client::AlgodClient;
-use algokit_transact::{Address, AlgorandMsgpack, SignedTransaction, Transaction};
-use async_trait::async_trait;
-
-// Implement TransactionSigner for TestAccount directly, eliminating the need for TestAccountSigner wrapper
-#[async_trait]
-impl TransactionSigner for TestAccount {
-    async fn sign_transactions(
-        &self,
-        txns: &[Transaction],
-        indices: &[usize],
-    ) -> Result<Vec<SignedTransaction>, String> {
-        indices
-            .iter()
-            .map(|&idx| {
-                if idx < txns.len() {
-                    // Use the TestAccount's sign_transaction method to get signed bytes
-                    let signed_bytes = self
-                        .sign_transaction(&txns[idx])
-                        .map_err(|e| format!("Failed to sign transaction: {}", e))?;
-
-                    // Decode the signed bytes back to SignedTransaction
-                    SignedTransaction::decode(&signed_bytes)
-                        .map_err(|e| format!("Failed to decode signed transaction: {}", e))
-                } else {
-                    Err(format!("Index {} out of bounds for transactions", idx))
-                }
-            })
-            .collect()
-    }
-}
-
-// Implement TransactionSignerGetter for TestAccount as well
-#[async_trait]
-impl TransactionSignerGetter for TestAccount {
-    async fn get_signer(&self, address: Address) -> Option<&dyn TransactionSigner> {
-        let test_account_address = self.account().expect("Failed to get test account address");
-        if address == test_account_address.address() {
-            Some(self)
-        } else {
-            None
-        }
-    }
-}
+use algokit_transact::Transaction;
 
 pub struct AlgorandFixture {
     config: AlgoConfig,
@@ -102,7 +60,7 @@ impl AlgorandFixture {
             .map_err(|e| format!("Failed to create test account: {}", e))?;
 
         // Now TestAccount implements TransactionSignerGetter directly, so we can use it without a wrapper
-        let composer = Composer::new(algod.clone(), Some(Arc::new(test_account.clone())));
+        let composer = Composer::new(algod.clone(), Arc::new(test_account.clone()));
 
         self.context = Some(AlgorandTestContext {
             algod,

--- a/crates/algokit_utils/src/transactions/common.rs
+++ b/crates/algokit_utils/src/transactions/common.rs
@@ -20,20 +20,11 @@ pub trait TransactionSigner: Send + Sync {
     }
 }
 
-#[async_trait]
-pub trait TransactionSignerGetter: Send + Sync {
-    async fn get_signer(&self, address: Address) -> Option<&dyn TransactionSigner>;
+pub trait TransactionSignerGetter {
+    fn get_signer(&self, address: Address) -> Option<Arc<dyn TransactionSigner>>;
 }
 
-pub struct DefaultSignerGetter;
-
-#[async_trait]
-impl TransactionSignerGetter for DefaultSignerGetter {
-    async fn get_signer(&self, _address: Address) -> Option<&dyn TransactionSigner> {
-        None
-    }
-}
-
+#[derive(Clone)]
 pub struct EmptySigner {}
 
 #[async_trait]
@@ -61,10 +52,9 @@ impl TransactionSigner for EmptySigner {
     }
 }
 
-#[async_trait]
 impl TransactionSignerGetter for EmptySigner {
-    async fn get_signer(&self, _address: Address) -> Option<&dyn TransactionSigner> {
-        Some(self)
+    fn get_signer(&self, _address: Address) -> Option<Arc<dyn TransactionSigner>> {
+        Some(Arc::new(self.clone()))
     }
 }
 

--- a/crates/algokit_utils/src/transactions/mod.rs
+++ b/crates/algokit_utils/src/transactions/mod.rs
@@ -11,9 +11,7 @@ pub use application_call::{
     ApplicationUpdateParams,
 };
 pub use asset_config::{AssetCreateParams, AssetDestroyParams, AssetReconfigureParams};
-pub use common::{
-    CommonParams, DefaultSignerGetter, EmptySigner, TransactionSigner, TransactionSignerGetter,
-};
+pub use common::{CommonParams, EmptySigner, TransactionSigner, TransactionSignerGetter};
 pub use composer::{Composer, ComposerError, ComposerTransaction};
 pub use key_registration::{
     NonParticipationKeyRegistrationParams, OfflineKeyRegistrationParams,

--- a/crates/algokit_utils/tests/algod/pending_transaction_information.rs
+++ b/crates/algokit_utils/tests/algod/pending_transaction_information.rs
@@ -1,7 +1,9 @@
 use algod_client::apis::Format;
-use algokit_transact::{PaymentTransactionBuilder, Transaction, TransactionHeaderBuilder};
+use algokit_transact::{
+    AlgorandMsgpack, PaymentTransactionBuilder, Transaction, TransactionHeaderBuilder,
+};
 use algokit_utils::{
-    ClientManager,
+    ClientManager, TransactionSigner,
     testing::{NetworkType, TestAccountConfig, TestAccountManager},
 };
 use std::convert::TryInto;
@@ -77,9 +79,11 @@ async fn test_pending_transaction_broadcast() {
         .expect("Failed to build payment fields");
 
     let transaction = Transaction::Payment(payment_fields);
-    let signed_bytes = sender
+    let signed_transaction = sender
         .sign_transaction(&transaction)
+        .await
         .expect("Failed to sign transaction");
+    let signed_bytes = signed_transaction.encode().unwrap();
 
     let response = algod_client
         .raw_transaction(signed_bytes)

--- a/crates/algokit_utils/tests/algod/raw_transaction.rs
+++ b/crates/algokit_utils/tests/algod/raw_transaction.rs
@@ -1,6 +1,8 @@
-use algokit_transact::{PaymentTransactionBuilder, Transaction, TransactionHeaderBuilder};
+use algokit_transact::{
+    AlgorandMsgpack, PaymentTransactionBuilder, Transaction, TransactionHeaderBuilder,
+};
 use algokit_utils::{
-    ClientManager,
+    ClientManager, TransactionSigner,
     testing::{NetworkType, TestAccountConfig, TestAccountManager},
 };
 use std::convert::TryInto;
@@ -76,9 +78,12 @@ async fn test_raw_transaction_broadcast() {
         .expect("Failed to build payment fields");
 
     let transaction = Transaction::Payment(payment_fields);
-    let signed_bytes = sender
+    let signed_transaction = sender
         .sign_transaction(&transaction)
+        .await
         .expect("Failed to sign transaction");
+
+    let signed_bytes = signed_transaction.encode().unwrap();
 
     let response = algod_client
         .raw_transaction(signed_bytes)

--- a/crates/algokit_utils/tests/transactions/composer/payment.rs
+++ b/crates/algokit_utils/tests/transactions/composer/payment.rs
@@ -122,3 +122,73 @@ async fn test_basic_account_close_transaction() {
         _ => panic!("Transaction should be a payment transaction"),
     }
 }
+
+#[tokio::test]
+async fn test_payment_transactions_with_signers() {
+    use std::sync::Arc;
+
+    init_test_logging();
+
+    let mut fixture = algorand_fixture().await.expect("Failed to create fixture");
+
+    fixture
+        .new_scope()
+        .await
+        .expect("Failed to create new scope");
+
+    // Generate a new account that will be the sender
+    let sender_account = fixture
+        .generate_account(None)
+        .await
+        .expect("Failed to create sender account");
+
+    let sender_addr = sender_account
+        .account()
+        .expect("Failed to get sender account")
+        .address();
+
+    let context = fixture.context().expect("Failed to get context");
+    let receiver_addr = context
+        .test_account
+        .account()
+        .expect("Failed to get receiver account")
+        .address();
+
+    let mut composer = context.composer.clone();
+    let signer = Arc::new(sender_account.clone());
+
+    // Add two payment transactions with the same signer
+    for i in 0..2 {
+        let payment_params = PaymentParams {
+            common_params: CommonParams {
+                sender: sender_addr.clone(),
+                signer: Some(signer.clone()),
+                ..Default::default()
+            },
+            receiver: receiver_addr.clone(),
+            amount: 50_000 + (i * 10_000),
+        };
+        composer
+            .add_payment(payment_params)
+            .expect("Failed to add payment");
+    }
+
+    let result = composer.send(None).await.expect("Failed to send payments");
+
+    // Verify the transaction was processed successfully
+    let transaction = &result.confirmations[0].txn.transaction;
+    match transaction {
+        algokit_transact::Transaction::Payment(payment_fields) => {
+            // This will be the first transaction in the group
+            assert_eq!(
+                payment_fields.header.sender, sender_addr,
+                "Transaction sender should be the sender account"
+            );
+            assert_eq!(
+                payment_fields.receiver, receiver_addr,
+                "Payment receiver should match test account address"
+            );
+        }
+        _ => panic!("Transaction should be a payment transaction"),
+    }
+}


### PR DESCRIPTION
When a signer is set in the transaction params, it should be used for signing. In this PR, I also added logic to batch signing (see `gather_signatures` function for efficiency.