### PR TITLE
Feat/add asset frz to txn composer v2

### DIFF
--- a/crates/algokit_utils/src/transactions/asset_freeze.rs
+++ b/crates/algokit_utils/src/transactions/asset_freeze.rs
@@ -1,0 +1,29 @@
+use algokit_transact::Address;
+
+use super::common::CommonParams;
+
+/// Parameters to freeze an asset for a target account.
+#[derive(Debug, Clone)]
+pub struct AssetFreezeParams {
+    /// Common transaction parameters.
+    pub common_params: CommonParams,
+
+    /// The ID of the asset being frozen.
+    pub asset_id: u64,
+
+    /// The target account whose asset holdings will be frozen.
+    pub freeze_target: Address,
+}
+
+/// Parameters to unfreeze an asset for a target account.
+#[derive(Debug, Clone)]
+pub struct AssetUnfreezeParams {
+    /// Common transaction parameters.
+    pub common_params: CommonParams,
+
+    /// The ID of the asset being unfrozen.
+    pub asset_id: u64,
+
+    /// The target account whose asset holdings will be unfrozen.
+    pub freeze_target: Address,
+}

--- a/crates/algokit_utils/src/transactions/asset_freeze.rs
+++ b/crates/algokit_utils/src/transactions/asset_freeze.rs
@@ -12,7 +12,7 @@ pub struct AssetFreezeParams {
     pub asset_id: u64,
 
     /// The target account whose asset holdings will be frozen.
-    pub freeze_target: Address,
+    pub target_address: Address,
 }
 
 /// Parameters to unfreeze an asset for a target account.
@@ -25,5 +25,5 @@ pub struct AssetUnfreezeParams {
     pub asset_id: u64,
 
     /// The target account whose asset holdings will be unfrozen.
-    pub freeze_target: Address,
+    pub target_address: Address,
 }

--- a/crates/algokit_utils/src/transactions/composer.rs
+++ b/crates/algokit_utils/src/transactions/composer.rs
@@ -19,6 +19,7 @@ use super::application_call::{
     ApplicationUpdateParams,
 };
 use super::asset_config::{AssetCreateParams, AssetDestroyParams, AssetReconfigureParams};
+use super::asset_freeze::{AssetFreezeParams, AssetUnfreezeParams};
 use super::common::{CommonParams, TransactionSigner, TransactionSignerGetter};
 use super::key_registration::{
     NonParticipationKeyRegistrationParams, OfflineKeyRegistrationParams,
@@ -119,6 +120,8 @@ pub enum ComposerTransaction {
     AssetCreate(AssetCreateParams),
     AssetReconfigure(AssetReconfigureParams),
     AssetDestroy(AssetDestroyParams),
+    AssetFreeze(AssetFreezeParams),
+    AssetUnfreeze(AssetUnfreezeParams),
     ApplicationCall(ApplicationCallParams),
     ApplicationCreate(ApplicationCreateParams),
     ApplicationUpdate(ApplicationUpdateParams),
@@ -155,6 +158,12 @@ impl ComposerTransaction {
             }
             ComposerTransaction::AssetDestroy(asset_destroy_params) => {
                 asset_destroy_params.common_params.clone()
+            }
+            ComposerTransaction::AssetFreeze(asset_freeze_params) => {
+                asset_freeze_params.common_params.clone()
+            }
+            ComposerTransaction::AssetUnfreeze(asset_unfreeze_params) => {
+                asset_unfreeze_params.common_params.clone()
             }
             ComposerTransaction::ApplicationCall(app_call_params) => {
                 app_call_params.common_params.clone()
@@ -283,6 +292,20 @@ impl Composer {
         asset_destroy_params: AssetDestroyParams,
     ) -> Result<(), ComposerError> {
         self.push(ComposerTransaction::AssetDestroy(asset_destroy_params))
+    }
+
+    pub fn add_asset_freeze(
+        &mut self,
+        asset_freeze_params: AssetFreezeParams,
+    ) -> Result<(), ComposerError> {
+        self.push(ComposerTransaction::AssetFreeze(asset_freeze_params))
+    }
+
+    pub fn add_asset_unfreeze(
+        &mut self,
+        asset_unfreeze_params: AssetUnfreezeParams,
+    ) -> Result<(), ComposerError> {
+        self.push(ComposerTransaction::AssetUnfreeze(asset_unfreeze_params))
     }
 
     pub fn add_online_key_registration(
@@ -529,6 +552,22 @@ impl Composer {
                         reserve: None,
                         freeze: None,
                         clawback: None,
+                    })
+                }
+                ComposerTransaction::AssetFreeze(asset_freeze_params) => {
+                    Transaction::AssetFreeze(algokit_transact::AssetFreezeTransactionFields {
+                        header,
+                        asset_id: asset_freeze_params.asset_id,
+                        freeze_target: asset_freeze_params.freeze_target.clone(),
+                        frozen: true,
+                    })
+                }
+                ComposerTransaction::AssetUnfreeze(asset_unfreeze_params) => {
+                    Transaction::AssetFreeze(algokit_transact::AssetFreezeTransactionFields {
+                        header,
+                        asset_id: asset_unfreeze_params.asset_id,
+                        freeze_target: asset_unfreeze_params.freeze_target.clone(),
+                        frozen: false,
                     })
                 }
                 ComposerTransaction::ApplicationCall(app_call_params) => {

--- a/crates/algokit_utils/src/transactions/composer.rs
+++ b/crates/algokit_utils/src/transactions/composer.rs
@@ -558,7 +558,7 @@ impl Composer {
                     Transaction::AssetFreeze(algokit_transact::AssetFreezeTransactionFields {
                         header,
                         asset_id: asset_freeze_params.asset_id,
-                        freeze_target: asset_freeze_params.freeze_target.clone(),
+                        freeze_target: asset_freeze_params.target_address.clone(),
                         frozen: true,
                     })
                 }
@@ -566,7 +566,7 @@ impl Composer {
                     Transaction::AssetFreeze(algokit_transact::AssetFreezeTransactionFields {
                         header,
                         asset_id: asset_unfreeze_params.asset_id,
-                        freeze_target: asset_unfreeze_params.freeze_target.clone(),
+                        freeze_target: asset_unfreeze_params.target_address.clone(),
                         frozen: false,
                     })
                 }

--- a/crates/algokit_utils/src/transactions/mod.rs
+++ b/crates/algokit_utils/src/transactions/mod.rs
@@ -1,5 +1,6 @@
 pub mod application_call;
 pub mod asset_config;
+pub mod asset_freeze;
 pub mod common;
 pub mod composer;
 pub mod key_registration;
@@ -11,8 +12,12 @@ pub use application_call::{
     ApplicationUpdateParams,
 };
 pub use asset_config::{AssetCreateParams, AssetDestroyParams, AssetReconfigureParams};
+pub use asset_freeze::{AssetFreezeParams, AssetUnfreezeParams};
 pub use common::{CommonParams, EmptySigner, TransactionSigner, TransactionSignerGetter};
-pub use composer::{Composer, ComposerError, ComposerTransaction};
+pub use composer::{
+    AssetClawbackParams, AssetOptInParams, AssetOptOutParams, AssetTransferParams, Composer,
+    ComposerError, ComposerTransaction,
+};
 pub use key_registration::{
     NonParticipationKeyRegistrationParams, OfflineKeyRegistrationParams,
     OnlineKeyRegistrationParams,

--- a/crates/algokit_utils/tests/transactions/composer/asset_freeze.rs
+++ b/crates/algokit_utils/tests/transactions/composer/asset_freeze.rs
@@ -1,4 +1,5 @@
 use algokit_transact::Transaction;
+use algokit_utils::transactions::AssetOptInParams;
 use algokit_utils::{CommonParams, Composer};
 use algokit_utils::{
     testing::*,
@@ -95,22 +96,18 @@ async fn test_asset_freeze_unfreeze() {
         .asset_index
         .expect("Failed to get asset ID");
 
-    println!("Created asset with ID: {}", asset_id);
-
     // Step 2: Target account opts into the asset
-    let asset_opt_in_params = AssetTransferParams {
+    let asset_opt_in_params = AssetOptInParams {
         common_params: CommonParams {
             sender: target_addr.clone(),
             ..Default::default()
         },
         asset_id,
-        amount: 0,
-        receiver: target_addr.clone(), // Receiver same as sender = opt-in
     };
 
     let mut composer = target_composer.clone();
     composer
-        .add_asset_transfer(asset_opt_in_params)
+        .add_asset_opt_in(asset_opt_in_params)
         .expect("Failed to add asset opt-in");
 
     let opt_in_result = composer

--- a/crates/algokit_utils/tests/transactions/composer/asset_freeze.rs
+++ b/crates/algokit_utils/tests/transactions/composer/asset_freeze.rs
@@ -1,0 +1,342 @@
+use algokit_transact::Transaction;
+use algokit_utils::{CommonParams, Composer};
+use algokit_utils::{
+    testing::*,
+    transactions::{
+        AssetCreateParams, AssetFreezeParams, AssetTransferParams, AssetUnfreezeParams,
+    },
+};
+
+use crate::common::init_test_logging;
+
+#[tokio::test]
+async fn test_asset_freeze_unfreeze_integration() {
+    // This integration test validates the complete asset freeze/unfreeze cycle by:
+    //
+    // SETUP PHASE:
+    // 1. Create an asset with freeze account set (unfrozen by default)
+    // 2. Target account opts into the asset
+    // 3. Transfer asset units to target account
+    //
+    // FREEZE PHASE:
+    // 4. Freeze the asset for target account using AssetFreezeParams
+    // 5. Verify freeze transaction was confirmed and has correct structure
+    // 6. Verify account holding shows asset is frozen via algod API
+    // 7. Prove freeze works by attempting transfer (should fail)
+    //
+    // UNFREEZE PHASE:
+    // 8. Unfreeze the asset for target account using AssetUnfreezeParams
+    // 9. Verify unfreeze transaction was confirmed and has correct structure
+    // 10. Verify account holding shows asset is no longer frozen via algod API
+    // 11. Prove unfreeze works by successfully transferring the asset
+
+    init_test_logging();
+
+    let mut fixture = algorand_fixture().await.expect("Failed to create fixture");
+    fixture
+        .new_scope()
+        .await
+        .expect("Failed to create new scope");
+
+    // Create a target account to hold the asset
+    let target_account = fixture
+        .generate_account(None)
+        .await
+        .expect("Failed to create target account");
+    let target_addr = target_account
+        .account()
+        .expect("Failed to get target account")
+        .address();
+
+    let context = fixture.context().expect("Failed to get context");
+    let freeze_account = context
+        .test_account
+        .account()
+        .expect("Failed to get freeze account");
+    let freeze_addr = freeze_account.address();
+
+    // Create a composer for the target account that can send transactions
+    let target_composer = Composer::new(
+        context.algod.clone(),
+        std::sync::Arc::new(target_account.clone()),
+    );
+
+    // SETUP PHASE
+
+    // Step 1: Create an asset with the freeze account set
+    let asset_create_params = AssetCreateParams {
+        common_params: CommonParams {
+            sender: freeze_addr.clone(),
+            ..Default::default()
+        },
+        total: 1_000_000,
+        decimals: Some(0),
+        default_frozen: Some(false),
+        asset_name: Some("Freeze Test Asset".to_string()),
+        unit_name: Some("FTA".to_string()),
+        url: None,
+        metadata_hash: None,
+        manager: Some(freeze_addr.clone()),
+        reserve: None,
+        freeze: Some(freeze_addr.clone()), // Set freeze account
+        clawback: None,
+    };
+
+    let mut composer = context.composer.clone();
+    composer
+        .add_asset_create(asset_create_params)
+        .expect("Failed to add asset create");
+
+    let create_result = composer
+        .send(None)
+        .await
+        .expect("Failed to send asset create");
+    let asset_id = create_result.confirmations[0]
+        .asset_index
+        .expect("Failed to get asset ID");
+
+    println!("Created asset with ID: {}", asset_id);
+
+    // Step 2: Target account opts into the asset
+    let asset_opt_in_params = AssetTransferParams {
+        common_params: CommonParams {
+            sender: target_addr.clone(),
+            ..Default::default()
+        },
+        asset_id,
+        amount: 0,
+        receiver: target_addr.clone(), // Receiver same as sender = opt-in
+    };
+
+    let mut composer = target_composer.clone();
+    composer
+        .add_asset_transfer(asset_opt_in_params)
+        .expect("Failed to add asset opt-in");
+
+    let opt_in_result = composer
+        .send(None)
+        .await
+        .expect("Failed to send asset opt-in");
+
+    assert!(
+        opt_in_result.confirmations[0].confirmed_round.is_some(),
+        "Asset opt-in should be confirmed"
+    );
+
+    println!("Target account opted into asset");
+
+    // Step 3: Send some asset units to the target account
+    let asset_transfer_params = AssetTransferParams {
+        common_params: CommonParams {
+            sender: freeze_addr.clone(),
+            ..Default::default()
+        },
+        asset_id,
+        amount: 1000,
+        receiver: target_addr.clone(),
+    };
+
+    let mut composer = context.composer.clone();
+    composer
+        .add_asset_transfer(asset_transfer_params)
+        .expect("Failed to add asset transfer");
+
+    let transfer_result = composer
+        .send(None)
+        .await
+        .expect("Failed to send asset transfer");
+
+    assert!(
+        transfer_result.confirmations[0].confirmed_round.is_some(),
+        "Asset transfer should be confirmed"
+    );
+
+    println!("Transferred 1000 asset units to target account");
+
+    // FREEZE PHASE
+
+    // Step 4: Freeze the asset for the target account
+    let asset_freeze_params = AssetFreezeParams {
+        common_params: CommonParams {
+            sender: freeze_addr.clone(),
+            ..Default::default()
+        },
+        asset_id,
+        freeze_target: target_addr.clone(),
+    };
+
+    let mut composer = context.composer.clone();
+    composer
+        .add_asset_freeze(asset_freeze_params)
+        .expect("Failed to add asset freeze");
+
+    let freeze_result = composer
+        .send(None)
+        .await
+        .expect("Failed to send asset freeze");
+
+    // Step 5: Verify freeze transaction was confirmed and has correct structure
+    let freeze_confirmation = &freeze_result.confirmations[0];
+    assert!(
+        freeze_confirmation.confirmed_round.is_some(),
+        "Asset freeze transaction should be confirmed"
+    );
+    assert!(
+        freeze_confirmation.confirmed_round.unwrap() > 0,
+        "Freeze confirmed round should be greater than 0"
+    );
+
+    match &freeze_confirmation.txn.transaction {
+        Transaction::AssetFreeze(txn) => {
+            assert_eq!(txn.asset_id, asset_id, "Asset ID should match");
+            assert_eq!(txn.freeze_target, target_addr, "Freeze target should match");
+            assert_eq!(txn.frozen, true, "Asset should be frozen");
+        }
+        _ => panic!("Transaction should be an AssetFreeze transaction"),
+    }
+
+    println!("Asset frozen for target account");
+
+    // Step 6: Verify account holding shows asset is frozen via algod API
+    let account_info = context
+        .algod
+        .account_information(None, &target_addr.to_string(), None)
+        .await
+        .expect("Failed to get account information");
+
+    let assets = account_info.assets.expect("Account should have assets");
+
+    let asset_holding = assets
+        .iter()
+        .find(|asset| asset.asset_id == asset_id)
+        .expect("Target account should have the asset");
+
+    assert!(
+        asset_holding.is_frozen,
+        "Asset should be frozen in account holding"
+    );
+
+    println!("Verified asset is frozen in account holding");
+
+    // Step 7: Prove freeze works by attempting transfer (should fail)
+    let attempt_transfer_params = AssetTransferParams {
+        common_params: CommonParams {
+            sender: target_addr.clone(),
+            ..Default::default()
+        },
+        asset_id,
+        amount: 100,
+        receiver: freeze_addr.clone(),
+    };
+
+    let mut composer = target_composer.clone();
+    composer
+        .add_asset_transfer(attempt_transfer_params)
+        .expect("Failed to add asset transfer attempt");
+
+    let transfer_attempt_result = composer.send(None).await;
+
+    assert!(
+        transfer_attempt_result.is_err(),
+        "Transfer of frozen asset should fail"
+    );
+
+    println!("Confirmed that frozen asset cannot be transferred");
+
+    // UNFREEZE PHASE
+
+    // Step 8: Unfreeze the asset for the target account
+    let asset_unfreeze_params = AssetUnfreezeParams {
+        common_params: CommonParams {
+            sender: freeze_addr.clone(),
+            ..Default::default()
+        },
+        asset_id,
+        freeze_target: target_addr.clone(),
+    };
+
+    let mut composer = context.composer.clone();
+    composer
+        .add_asset_unfreeze(asset_unfreeze_params)
+        .expect("Failed to add asset unfreeze");
+
+    let unfreeze_result = composer
+        .send(None)
+        .await
+        .expect("Failed to send asset unfreeze");
+
+    // Step 9: Verify unfreeze transaction was confirmed and has correct structure
+    let unfreeze_confirmation = &unfreeze_result.confirmations[0];
+    assert!(
+        unfreeze_confirmation.confirmed_round.is_some(),
+        "Asset unfreeze transaction should be confirmed"
+    );
+    assert!(
+        unfreeze_confirmation.confirmed_round.unwrap() > 0,
+        "Unfreeze confirmed round should be greater than 0"
+    );
+
+    match &unfreeze_confirmation.txn.transaction {
+        Transaction::AssetFreeze(txn) => {
+            assert_eq!(txn.asset_id, asset_id, "Asset ID should match");
+            assert_eq!(txn.freeze_target, target_addr, "Freeze target should match");
+            assert_eq!(txn.frozen, false, "Asset should be unfrozen");
+        }
+        _ => panic!("Transaction should be an AssetFreeze transaction"),
+    }
+
+    println!("Asset unfrozen for target account");
+
+    // Step 10: Verify account holding shows asset is no longer frozen via algod API
+    let account_info_after = context
+        .algod
+        .account_information(None, &target_addr.to_string(), None)
+        .await
+        .expect("Failed to get account information after unfreeze");
+
+    let assets_after = account_info_after
+        .assets
+        .expect("Account should still have assets");
+
+    let asset_holding_after = assets_after
+        .iter()
+        .find(|asset| asset.asset_id == asset_id)
+        .expect("Target account should still have the asset");
+
+    assert!(
+        !asset_holding_after.is_frozen,
+        "Asset should no longer be frozen in account holding"
+    );
+
+    println!("Verified asset is no longer frozen in account holding");
+
+    // Step 11: Prove unfreeze works by successfully transferring the asset
+    let test_transfer_params = AssetTransferParams {
+        common_params: CommonParams {
+            sender: target_addr.clone(),
+            ..Default::default()
+        },
+        asset_id,
+        amount: 100,
+        receiver: freeze_addr.clone(), // Transfer back to freeze account
+    };
+
+    let mut composer = target_composer.clone();
+    composer
+        .add_asset_transfer(test_transfer_params)
+        .expect("Failed to add test asset transfer");
+
+    let test_transfer_result = composer
+        .send(None)
+        .await
+        .expect("Failed to send test asset transfer - asset should be unfrozen");
+
+    assert!(
+        test_transfer_result.confirmations[0]
+            .confirmed_round
+            .is_some(),
+        "Test asset transfer should be confirmed, proving asset is unfrozen"
+    );
+
+    println!("Successfully transferred asset, confirming it's unfrozen");
+}

--- a/crates/algokit_utils/tests/transactions/composer/asset_freeze.rs
+++ b/crates/algokit_utils/tests/transactions/composer/asset_freeze.rs
@@ -15,7 +15,7 @@ async fn test_asset_freeze_unfreeze() {
     // This integration test validates the complete asset freeze/unfreeze cycle by:
     //
     // SETUP PHASE:
-    // 1. Create an asset with freeze account set (unfrozen by default)
+    // 1. Create an asset with the asset creator account set as the freeze account (unfrozen by default)
     // 2. Target account opts into the asset
     // 3. Transfer asset units to target account
     //
@@ -53,7 +53,7 @@ async fn test_asset_freeze_unfreeze() {
     let asset_creator_account = context
         .test_account
         .account()
-        .expect("Failed to get freeze account");
+        .expect("Failed to get asset creator account");
     let asset_creator_addr = asset_creator_account.address();
 
     // Create a composer for the target account that can send transactions
@@ -64,7 +64,7 @@ async fn test_asset_freeze_unfreeze() {
 
     // SETUP PHASE
 
-    // Step 1: Create an asset with the freeze account set
+    // Step 1: Create an asset with the asset creator account set as the freeze account
     let asset_create_params = AssetCreateParams {
         common_params: CommonParams {
             sender: asset_creator_addr.clone(),
@@ -79,7 +79,7 @@ async fn test_asset_freeze_unfreeze() {
         metadata_hash: None,
         manager: Some(asset_creator_addr.clone()),
         reserve: None,
-        freeze: Some(asset_creator_addr.clone()), // Set freeze account
+        freeze: Some(asset_creator_addr.clone()),
         clawback: None,
     };
 
@@ -322,7 +322,7 @@ async fn test_asset_freeze_unfreeze() {
         },
         asset_id,
         amount: 100,
-        receiver: asset_creator_addr.clone(), // Transfer back to freeze account
+        receiver: asset_creator_addr.clone(),
     };
 
     let mut composer = target_composer.clone();

--- a/crates/algokit_utils/tests/transactions/composer/asset_freeze.rs
+++ b/crates/algokit_utils/tests/transactions/composer/asset_freeze.rs
@@ -162,7 +162,7 @@ async fn test_asset_freeze_unfreeze() {
             ..Default::default()
         },
         asset_id,
-        freeze_target: target_addr.clone(),
+        target_address: target_addr.clone(),
     };
 
     let mut composer = context.composer.clone();
@@ -190,7 +190,7 @@ async fn test_asset_freeze_unfreeze() {
         Transaction::AssetFreeze(txn) => {
             assert_eq!(txn.asset_id, asset_id, "Asset ID should match");
             assert_eq!(txn.freeze_target, target_addr, "Freeze target should match");
-            assert_eq!(txn.frozen, true, "Asset should be frozen");
+            assert!(txn.frozen, "Asset should be frozen");
         }
         _ => panic!("Transaction should be an AssetFreeze transaction"),
     }
@@ -240,10 +240,10 @@ async fn test_asset_freeze_unfreeze() {
         transfer_attempt_result.is_err(),
         "Transfer of frozen asset should fail"
     );
-    // Verify the error is related to the account being marked as non-participating
+    // Verify the error is related to the asset being frozen
     let error_message = transfer_attempt_result.unwrap_err().to_string();
     assert!(
-        error_message.contains(&format!("asset {} is frozen", asset_id)),
+        error_message.contains(&format!("asset {} frozen", asset_id)),
         "Error should indicate the asset is frozen: {}",
         error_message
     );
@@ -259,7 +259,7 @@ async fn test_asset_freeze_unfreeze() {
             ..Default::default()
         },
         asset_id,
-        freeze_target: target_addr.clone(),
+        target_address: target_addr.clone(),
     };
 
     let mut composer = context.composer.clone();
@@ -287,7 +287,7 @@ async fn test_asset_freeze_unfreeze() {
         Transaction::AssetFreeze(txn) => {
             assert_eq!(txn.asset_id, asset_id, "Asset ID should match");
             assert_eq!(txn.freeze_target, target_addr, "Freeze target should match");
-            assert_eq!(txn.frozen, false, "Asset should be unfrozen");
+            assert!(!txn.frozen, "Asset should be unfrozen");
         }
         _ => panic!("Transaction should be an AssetFreeze transaction"),
     }

--- a/crates/algokit_utils/tests/transactions/composer/mod.rs
+++ b/crates/algokit_utils/tests/transactions/composer/mod.rs
@@ -1,5 +1,6 @@
 pub mod application_call;
 pub mod asset_config;
+pub mod asset_freeze;
 pub mod asset_transfer;
 pub mod key_registration;
 pub mod payment;

--- a/packages/typescript/algokit_transact/__tests__/asset_freeze.test.ts
+++ b/packages/typescript/algokit_transact/__tests__/asset_freeze.test.ts
@@ -13,8 +13,8 @@ import {
 } from "./transaction_asserts";
 
 const freezeTestData = Object.entries({
-  ["freeze"]: testData.assetFreeze,
-  ["unfreeze"]: testData.assetUnfreeze,
+  freeze: testData.assetFreeze,
+  unfreeze: testData.assetUnfreeze,
 });
 
 describe("Asset Freeze", () => {

--- a/packages/typescript/algokit_transact/__tests__/common.ts
+++ b/packages/typescript/algokit_transact/__tests__/common.ts
@@ -38,11 +38,11 @@ const defaultReviver = (key: string, value: unknown) => {
   // 2. When deserializing, missing values default to false
   // The TypeScript WASM bindings expect the field to always be present as a boolean
   if (key === "assetFreeze" && typeof value === "object" && value !== null) {
-    const assetObject = value as any;
-    if (assetObject.frozen === undefined) {
-      assetObject.frozen = false; // Match WASM bindings' expectations
+    const assetFreeze = value as any;
+    if (assetFreeze.frozen === undefined) {
+      assetFreeze.frozen = false; // Match WASM bindings' expectations
     }
-    return assetObject;
+    return assetFreeze;
   }
 
   return value;

--- a/packages/typescript/algokit_transact/__tests__/common.ts
+++ b/packages/typescript/algokit_transact/__tests__/common.ts
@@ -37,7 +37,7 @@ const defaultReviver = (key: string, value: unknown) => {
   // 1. When serializing, false values may be omitted from JSON
   // 2. When deserializing, missing values default to false
   // The TypeScript WASM bindings expect the field to always be present as a boolean
-  if ((key === "assetFreeze" || key === "assetUnfreeze") && typeof value === "object" && value !== null) {
+  if (key === "assetFreeze" && typeof value === "object" && value !== null) {
     const assetObject = value as any;
     if (assetObject.frozen === undefined) {
       assetObject.frozen = false; // Match WASM bindings' expectations


### PR DESCRIPTION
This PR replaces #198. Did a rebase on #167. That was easier than updating that branch and dealing with merge conflicts. 

This branch was based on https://github.com/algorandfoundation/algokit-core/pull/167. Once that is merged, I'll rebase main.

Adds support for creating and building asset freeze/unfreeze transactions in the transaction composer. This enables users to freeze and unfreeze ASAs using the high-level composer API in the core-utils.

Changes
Added AssetFreezeParams and AssetUnfreezeParams structs for explicit freeze/unfreeze operations
Extended Composer with add_asset_freeze and add_asset_unfreeze methods
Added integration tests to verify both operations