### PR TITLE
fix: python CI CD

### DIFF
--- a/packages/python/algokit_transact/pyproject.toml
+++ b/packages/python/algokit_transact/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 requires-python = ">=3.9,<4.0"
 name = "algokit_transact"
-version = "1.0.0a30"
+version = "1.0.0a29"
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "setuptools", "wheel"]


### PR DESCRIPTION
As discussed, this PR rollbacks the python package version in the manifest to fix the python release pipeline.

It also predisposes the correct trigger `merge_group` for when we enable merge queues