### PR TITLE
feat: Implements string, bytes, bool abi encoding decoding, adds tests references from py and js sdks

### DIFF
--- a/crates/algokit_abi/src/abi_address_type.rs
+++ b/crates/algokit_abi/src/abi_address_type.rs
@@ -1,21 +1,164 @@
 use crate::{error::ABIError, ABIType, ABIValue};
 
+/// Encode an address value to ABI format.
+/// Addresses are encoded as 32-byte public keys.
 pub fn encode_address(abi_type: ABIType, value: ABIValue) -> Result<Vec<u8>, ABIError> {
     match abi_type {
         ABIType::ABIAddressType => {
-            let value = match value {
+            let address_bytes = match value {
                 ABIValue::Address(a) => a,
                 _ => {
-                    return Err(ABIError::EncodingError(format!(
-                        "Cannot encode value as address: expected a 32-byte array",
-                    )));
+                    return Err(ABIError::EncodingError(
+                        "Cannot encode value as address: expected a 32-byte array".to_string(),
+                    ));
                 }
             };
 
-            return Ok(value.to_vec());
+            Ok(address_bytes.to_vec())
         }
         _ => Err(ABIError::EncodingError(
             "Expected ABIAddressType".to_string(),
         )),
+    }
+}
+
+/// Decode an address value from ABI format.
+/// Expects exactly 32 bytes and returns an Address ABIValue.
+pub fn decode_address(abi_type: ABIType, bytes: Vec<u8>) -> Result<ABIValue, ABIError> {
+    match abi_type {
+        ABIType::ABIAddressType => {
+            if bytes.len() != 32 {
+                return Err(ABIError::DecodingError(
+                    "Address byte string must be 32 bytes long".to_string(),
+                ));
+            }
+
+            let mut address_bytes = [0u8; 32];
+            address_bytes.copy_from_slice(&bytes);
+            Ok(ABIValue::Address(address_bytes))
+        }
+        _ => Err(ABIError::DecodingError(
+            "Expected ABIAddressType".to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_ADDRESS_BYTES: [u8; 32] = [
+        0x61, 0x37, 0x3f, 0x95, 0x3e, 0x87, 0x9f, 0x48, 0x9f, 0x95, 0x53, 0x42, 0x20, 0x20, 0x91,
+        0x35, 0x2f, 0x59, 0x56, 0x02, 0x19, 0x99, 0x91, 0x11, 0x61, 0x07, 0x49, 0x5a, 0x5c, 0x4f,
+        0x71, 0x00,
+    ];
+
+    #[test]
+    fn test_address_round_trip() {
+        let value = ABIValue::Address(TEST_ADDRESS_BYTES);
+        let encoded = encode_address(ABIType::ABIAddressType, value.clone()).unwrap();
+        let decoded = decode_address(ABIType::ABIAddressType, encoded).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn test_address_encoding() {
+        let value = ABIValue::Address(TEST_ADDRESS_BYTES);
+        let encoded = encode_address(ABIType::ABIAddressType, value).unwrap();
+        assert_eq!(encoded, TEST_ADDRESS_BYTES.to_vec());
+    }
+
+    #[test]
+    fn test_address_decoding() {
+        let bytes = TEST_ADDRESS_BYTES.to_vec();
+        let decoded = decode_address(ABIType::ABIAddressType, bytes).unwrap();
+        assert_eq!(decoded, ABIValue::Address(TEST_ADDRESS_BYTES));
+    }
+
+    #[test]
+    fn test_multiple_addresses_round_trip() {
+        let test_addresses = vec![
+            [0u8; 32],
+            [0xFFu8; 32],
+            TEST_ADDRESS_BYTES,
+            [
+                0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66,
+                0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00, 0x01, 0x02, 0x03, 0x04,
+                0x05, 0x06, 0x07, 0x08,
+            ],
+        ];
+
+        for test_address in test_addresses {
+            let value = ABIValue::Address(test_address);
+            let encoded = encode_address(ABIType::ABIAddressType, value.clone()).unwrap();
+            let decoded = decode_address(ABIType::ABIAddressType, encoded).unwrap();
+            assert_eq!(decoded, value);
+        }
+    }
+
+    #[test]
+    fn test_encode_wrong_type() {
+        let value = ABIValue::String("not an address".to_string());
+        let result = encode_address(ABIType::ABIAddressType, value);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Cannot encode value as address"));
+    }
+
+    #[test]
+    fn test_encode_wrong_abi_type() {
+        let value = ABIValue::Address(TEST_ADDRESS_BYTES);
+        let result = encode_address(ABIType::ABIStringType, value);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Expected ABIAddressType"));
+    }
+
+    #[test]
+    fn test_decode_wrong_length_too_short() {
+        let bytes = vec![0u8; 31];
+        let result = decode_address(ABIType::ABIAddressType, bytes);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Address byte string must be 32 bytes long"));
+    }
+
+    #[test]
+    fn test_decode_wrong_length_too_long() {
+        let bytes = vec![0u8; 33];
+        let result = decode_address(ABIType::ABIAddressType, bytes);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Address byte string must be 32 bytes long"));
+    }
+
+    #[test]
+    fn test_decode_empty_bytes() {
+        let bytes = vec![];
+        let result = decode_address(ABIType::ABIAddressType, bytes);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Address byte string must be 32 bytes long"));
+    }
+
+    #[test]
+    fn test_decode_wrong_abi_type() {
+        let bytes = TEST_ADDRESS_BYTES.to_vec();
+        let result = decode_address(ABIType::ABIStringType, bytes);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Expected ABIAddressType"));
     }
 }

--- a/crates/algokit_abi/src/abi_bool_type.rs
+++ b/crates/algokit_abi/src/abi_bool_type.rs
@@ -1,0 +1,143 @@
+use crate::{error::ABIError, ABIType, ABIValue};
+
+/// Encode a boolean value to ABI format.
+/// True values are encoded as 0x80, false values as 0x00.
+pub fn encode_bool(abi_type: ABIType, value: ABIValue) -> Result<Vec<u8>, ABIError> {
+    match abi_type {
+        ABIType::ABIBoolType => {
+            let bool_value = match value {
+                ABIValue::Bool(b) => b,
+                _ => {
+                    return Err(ABIError::EncodingError(
+                        "Cannot encode value as bool: expected a boolean".to_string(),
+                    ));
+                }
+            };
+
+            if bool_value {
+                Ok(vec![0x80]) // true -> 128 (MSB set)
+            } else {
+                Ok(vec![0x00]) // false -> 0
+            }
+        }
+        _ => Err(ABIError::EncodingError(
+            "Expected ABIBoolType".to_string(),
+        )),
+    }
+}
+
+/// Decode a boolean value from ABI format.
+/// Expects exactly 1 byte: 0x80 for true, 0x00 for false.
+pub fn decode_bool(abi_type: ABIType, bytes: Vec<u8>) -> Result<ABIValue, ABIError> {
+    match abi_type {
+        ABIType::ABIBoolType => {
+            if bytes.len() != 1 {
+                return Err(ABIError::DecodingError(
+                    "Bool string must be 1 byte long".to_string(),
+                ));
+            }
+
+            match bytes[0] {
+                0x80 => Ok(ABIValue::Bool(true)),
+                0x00 => Ok(ABIValue::Bool(false)),
+                _ => Err(ABIError::DecodingError(
+                    "Boolean could not be decoded from the byte string".to_string(),
+                )),
+            }
+        }
+        _ => Err(ABIError::DecodingError(
+            "Expected ABIBoolType".to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_true() {
+        let abi_type = ABIType::ABIBoolType;
+        let value = ABIValue::Bool(true);
+        let encoded = encode_bool(abi_type, value).unwrap();
+        assert_eq!(encoded, vec![128]); // 0x80
+    }
+
+    #[test]
+    fn test_encode_false() {
+        let abi_type = ABIType::ABIBoolType;
+        let value = ABIValue::Bool(false);
+        let encoded = encode_bool(abi_type, value).unwrap();
+        assert_eq!(encoded, vec![0]); // 0x00
+    }
+
+    #[test]
+    fn test_decode_true() {
+        let abi_type = ABIType::ABIBoolType;
+        let bytes = vec![128]; // 0x80
+        let decoded = decode_bool(abi_type, bytes).unwrap();
+        assert_eq!(decoded, ABIValue::Bool(true));
+    }
+
+    #[test]
+    fn test_decode_false() {
+        let abi_type = ABIType::ABIBoolType;
+        let bytes = vec![0]; // 0x00
+        let decoded = decode_bool(abi_type, bytes).unwrap();
+        assert_eq!(decoded, ABIValue::Bool(false));
+    }
+
+    #[test]
+    fn test_round_trip() {
+        let test_cases = vec![true, false];
+
+        for test_bool in test_cases {
+            let value = ABIValue::Bool(test_bool);
+
+            let encoded = encode_bool(ABIType::ABIBoolType, value.clone()).unwrap();
+            let decoded = decode_bool(ABIType::ABIBoolType, encoded).unwrap();
+
+            assert_eq!(decoded, value);
+        }
+    }
+
+    #[test]
+    fn test_encode_wrong_type() {
+        let abi_type = ABIType::ABIBoolType;
+        let value = ABIValue::String("true".to_string());
+
+        let result = encode_bool(abi_type, value);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Cannot encode value as bool"));
+    }
+
+    #[test]
+    fn test_decode_wrong_length() {
+        let abi_type = ABIType::ABIBoolType;
+        let bytes = vec![0x80, 0x00]; // 2 bytes instead of 1
+
+        let result = decode_bool(abi_type, bytes);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Bool string must be 1 byte long"));
+    }
+
+    #[test]
+    fn test_decode_invalid_value() {
+        let abi_type = ABIType::ABIBoolType;
+        let bytes = vec![0x30]; // Invalid value (not 0x80 or 0x00)
+
+        let result = decode_bool(abi_type, bytes);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Boolean could not be decoded"));
+    }
+
+    #[test]
+    fn test_decode_wrong_abi_type() {
+        let abi_type = ABIType::ABIStringType;
+        let bytes = vec![0x80];
+
+        let result = decode_bool(abi_type, bytes);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Expected ABIBoolType"));
+    }
+}

--- a/crates/algokit_abi/src/abi_bool_type.rs
+++ b/crates/algokit_abi/src/abi_bool_type.rs
@@ -20,9 +20,7 @@ pub fn encode_bool(abi_type: ABIType, value: ABIValue) -> Result<Vec<u8>, ABIErr
                 Ok(vec![0x00]) // false -> 0
             }
         }
-        _ => Err(ABIError::EncodingError(
-            "Expected ABIBoolType".to_string(),
-        )),
+        _ => Err(ABIError::EncodingError("Expected ABIBoolType".to_string())),
     }
 }
 
@@ -45,9 +43,7 @@ pub fn decode_bool(abi_type: ABIType, bytes: Vec<u8>) -> Result<ABIValue, ABIErr
                 )),
             }
         }
-        _ => Err(ABIError::DecodingError(
-            "Expected ABIBoolType".to_string(),
-        )),
+        _ => Err(ABIError::DecodingError("Expected ABIBoolType".to_string())),
     }
 }
 
@@ -108,7 +104,10 @@ mod tests {
 
         let result = encode_bool(abi_type, value);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Cannot encode value as bool"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Cannot encode value as bool"));
     }
 
     #[test]
@@ -118,7 +117,10 @@ mod tests {
 
         let result = decode_bool(abi_type, bytes);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Bool string must be 1 byte long"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Bool string must be 1 byte long"));
     }
 
     #[test]
@@ -128,7 +130,10 @@ mod tests {
 
         let result = decode_bool(abi_type, bytes);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Boolean could not be decoded"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Boolean could not be decoded"));
     }
 
     #[test]
@@ -138,6 +143,9 @@ mod tests {
 
         let result = decode_bool(abi_type, bytes);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Expected ABIBoolType"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Expected ABIBoolType"));
     }
 }

--- a/crates/algokit_abi/src/abi_byte_type.rs
+++ b/crates/algokit_abi/src/abi_byte_type.rs
@@ -1,0 +1,164 @@
+use crate::{error::ABIError, ABIType, ABIValue};
+
+/// Encode a byte value (0-255) to ABI format.
+/// Values must be in the range 0-255 inclusive.
+pub fn encode_byte(abi_type: ABIType, value: ABIValue) -> Result<Vec<u8>, ABIError> {
+    match abi_type {
+        ABIType::ABIByteType => {
+            let byte_value = match value {
+                ABIValue::Uint(n) => {
+                    // Convert BigUint to u64 for range checking
+                    if n > num_bigint::BigUint::from(255u8) {
+                        return Err(ABIError::EncodingError(format!(
+                            "{} cannot be encoded into a byte",
+                            n
+                        )));
+                    }
+                    // Handle the case where BigUint is 0 (empty digits)
+                    if n.to_u64_digits().is_empty() {
+                        0u8
+                    } else {
+                        n.to_u64_digits()[0] as u8
+                    }
+                }
+                _ => {
+                    return Err(ABIError::EncodingError(
+                        "Cannot encode value as byte: expected a number".to_string(),
+                    ));
+                }
+            };
+
+            Ok(vec![byte_value])
+        }
+        _ => Err(ABIError::EncodingError(
+            "Expected ABIByteType".to_string(),
+        )),
+    }
+}
+
+/// Decode a byte value from ABI format.
+/// Expects exactly 1 byte and returns the value as a BigUint.
+pub fn decode_byte(abi_type: ABIType, bytes: Vec<u8>) -> Result<ABIValue, ABIError> {
+    match abi_type {
+        ABIType::ABIByteType => {
+            if bytes.len() != 1 {
+                return Err(ABIError::DecodingError(
+                    "Byte string must be 1 byte long".to_string(),
+                ));
+            }
+
+            Ok(ABIValue::Uint(num_bigint::BigUint::from(bytes[0])))
+        }
+        _ => Err(ABIError::DecodingError(
+            "Expected ABIByteType".to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use num_bigint::BigUint;
+
+    #[test]
+    fn test_encode_byte_10() {
+        let abi_type = ABIType::ABIByteType;
+        let value = ABIValue::Uint(BigUint::from(10u8));
+        let encoded = encode_byte(abi_type, value).unwrap();
+        assert_eq!(encoded, vec![10]);
+    }
+
+    #[test]
+    fn test_encode_byte_255() {
+        let abi_type = ABIType::ABIByteType;
+        let value = ABIValue::Uint(BigUint::from(255u8));
+        let encoded = encode_byte(abi_type, value).unwrap();
+        assert_eq!(encoded, vec![255]);
+    }
+
+    #[test]
+    fn test_encode_byte_0() {
+        let abi_type = ABIType::ABIByteType;
+        let value = ABIValue::Uint(BigUint::from(0u8));
+        let encoded = encode_byte(abi_type, value).unwrap();
+        assert_eq!(encoded, vec![0]);
+    }
+
+    #[test]
+    fn test_decode_byte_10() {
+        let abi_type = ABIType::ABIByteType;
+        let bytes = vec![10];
+        let decoded = decode_byte(abi_type, bytes).unwrap();
+        assert_eq!(decoded, ABIValue::Uint(BigUint::from(10u8)));
+    }
+
+    #[test]
+    fn test_decode_byte_255() {
+        let abi_type = ABIType::ABIByteType;
+        let bytes = vec![255];
+        let decoded = decode_byte(abi_type, bytes).unwrap();
+        assert_eq!(decoded, ABIValue::Uint(BigUint::from(255u8)));
+    }
+
+    #[test]
+    fn test_decode_byte_0() {
+        let abi_type = ABIType::ABIByteType;
+        let bytes = vec![0];
+        let decoded = decode_byte(abi_type, bytes).unwrap();
+        assert_eq!(decoded, ABIValue::Uint(BigUint::from(0u8)));
+    }
+
+    #[test]
+    fn test_round_trip() {
+        let test_cases = vec![0u8, 1u8, 10u8, 255u8];
+
+        for test_byte in test_cases {
+            let value = ABIValue::Uint(BigUint::from(test_byte));
+
+            let encoded = encode_byte(ABIType::ABIByteType, value.clone()).unwrap();
+            let decoded = decode_byte(ABIType::ABIByteType, encoded).unwrap();
+
+            assert_eq!(decoded, value);
+        }
+    }
+
+    #[test]
+    fn test_encode_out_of_range() {
+        let abi_type = ABIType::ABIByteType;
+        let value = ABIValue::Uint(BigUint::from(256u32));
+
+        let result = encode_byte(abi_type, value);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cannot be encoded into a byte"));
+    }
+
+    #[test]
+    fn test_encode_wrong_type() {
+        let abi_type = ABIType::ABIByteType;
+        let value = ABIValue::String("10".to_string());
+
+        let result = encode_byte(abi_type, value);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Cannot encode value as byte"));
+    }
+
+    #[test]
+    fn test_decode_wrong_length() {
+        let abi_type = ABIType::ABIByteType;
+        let bytes = vec![10, 20]; // 2 bytes instead of 1
+
+        let result = decode_byte(abi_type, bytes);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Byte string must be 1 byte long"));
+    }
+
+    #[test]
+    fn test_decode_wrong_abi_type() {
+        let abi_type = ABIType::ABIStringType;
+        let bytes = vec![10];
+
+        let result = decode_byte(abi_type, bytes);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Expected ABIByteType"));
+    }
+}

--- a/crates/algokit_abi/src/abi_byte_type.rs
+++ b/crates/algokit_abi/src/abi_byte_type.rs
@@ -30,9 +30,7 @@ pub fn encode_byte(abi_type: ABIType, value: ABIValue) -> Result<Vec<u8>, ABIErr
 
             Ok(vec![byte_value])
         }
-        _ => Err(ABIError::EncodingError(
-            "Expected ABIByteType".to_string(),
-        )),
+        _ => Err(ABIError::EncodingError("Expected ABIByteType".to_string())),
     }
 }
 
@@ -49,9 +47,7 @@ pub fn decode_byte(abi_type: ABIType, bytes: Vec<u8>) -> Result<ABIValue, ABIErr
 
             Ok(ABIValue::Uint(num_bigint::BigUint::from(bytes[0])))
         }
-        _ => Err(ABIError::DecodingError(
-            "Expected ABIByteType".to_string(),
-        )),
+        _ => Err(ABIError::DecodingError("Expected ABIByteType".to_string())),
     }
 }
 
@@ -129,7 +125,10 @@ mod tests {
 
         let result = encode_byte(abi_type, value);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("cannot be encoded into a byte"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("cannot be encoded into a byte"));
     }
 
     #[test]
@@ -139,7 +138,10 @@ mod tests {
 
         let result = encode_byte(abi_type, value);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Cannot encode value as byte"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Cannot encode value as byte"));
     }
 
     #[test]
@@ -149,7 +151,10 @@ mod tests {
 
         let result = decode_byte(abi_type, bytes);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Byte string must be 1 byte long"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Byte string must be 1 byte long"));
     }
 
     #[test]
@@ -159,6 +164,9 @@ mod tests {
 
         let result = decode_byte(abi_type, bytes);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Expected ABIByteType"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Expected ABIByteType"));
     }
 }

--- a/crates/algokit_abi/src/abi_string_type.rs
+++ b/crates/algokit_abi/src/abi_string_type.rs
@@ -1,0 +1,155 @@
+use crate::{error::ABIError, ABIType, ABIValue};
+
+const ABI_LENGTH_SIZE: usize = 2;
+
+pub fn encode_string(abi_type: ABIType, value: ABIValue) -> Result<Vec<u8>, ABIError> {
+    match abi_type {
+        ABIType::ABIStringType => {
+            let value = match value {
+                ABIValue::String(s) => s,
+                _ => {
+                    return Err(ABIError::EncodingError(
+                        "Cannot encode value as string: expected a String".to_string(),
+                    ));
+                }
+            };
+
+            let utf8_bytes = value.into_bytes();
+            let length = utf8_bytes.len() as u16;
+            let mut result = Vec::with_capacity(2 + utf8_bytes.len());
+            result.extend_from_slice(&length.to_be_bytes());
+            result.extend_from_slice(&utf8_bytes);
+
+            Ok(result)
+        }
+        _ => Err(ABIError::EncodingError(
+            "Expected ABIStringType".to_string(),
+        )),
+    }
+}
+
+pub fn decode_string(abi_type: ABIType, value: Vec<u8>) -> Result<ABIValue, ABIError> {
+    match abi_type {
+        ABIType::ABIStringType => {
+            if value.len() < ABI_LENGTH_SIZE {
+                return Err(ABIError::DecodingError(
+                    "Byte array too short for string".to_string(),
+                ));
+            }
+
+            let length = u16::from_be_bytes([value[0], value[1]]) as usize;
+            let content_bytes = &value[ABI_LENGTH_SIZE..];
+            if content_bytes.len() != length {
+                return Err(ABIError::DecodingError(format!(
+                    "Invalid byte array length for string, expected {} value, got {}",
+                    length,
+                    content_bytes.len()
+                )));
+            }
+
+            let string_value = String::from_utf8(content_bytes.to_vec())
+                .map_err(|_| ABIError::DecodingError("Invalid UTF-8 encoding".to_string()))?;
+            Ok(ABIValue::String(string_value))
+        }
+        _ => Err(ABIError::DecodingError(
+            "Expected ABIStringType".to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_asdf() {
+        let abi_type = ABIType::ABIStringType;
+        let value = ABIValue::String("asdf".to_string());
+        let encoded = encode_string(abi_type, value).unwrap();
+        assert_eq!(encoded, vec![0, 4, 97, 115, 100, 102]);
+    }
+
+    #[test]
+    fn test_encode_whats_new() {
+        let abi_type = ABIType::ABIStringType;
+        let value = ABIValue::String("What's new?".to_string());
+        let encoded = encode_string(abi_type, value).unwrap();
+        assert_eq!(
+            encoded,
+            vec![0, 11, 87, 104, 97, 116, 39, 115, 32, 110, 101, 119, 63]
+        );
+    }
+
+    #[test]
+    fn test_encode_emoji() {
+        let abi_type = ABIType::ABIStringType;
+        let value = ABIValue::String("😅🔨".to_string());
+        let encoded = encode_string(abi_type, value).unwrap();
+        assert_eq!(encoded, vec![0, 8, 240, 159, 152, 133, 240, 159, 148, 168]);
+    }
+
+    #[test]
+    fn test_decode_asdf() {
+        let abi_type = ABIType::ABIStringType;
+        let bytes = vec![0, 4, 97, 115, 100, 102];
+        let decoded = decode_string(abi_type, bytes).unwrap();
+        assert_eq!(decoded, ABIValue::String("asdf".to_string()));
+    }
+
+    #[test]
+    fn test_decode_whats_new() {
+        let abi_type = ABIType::ABIStringType;
+        let bytes = vec![0, 11, 87, 104, 97, 116, 39, 115, 32, 110, 101, 119, 63];
+        let decoded = decode_string(abi_type, bytes).unwrap();
+        assert_eq!(decoded, ABIValue::String("What's new?".to_string()));
+    }
+
+    #[test]
+    fn test_decode_emoji() {
+        let abi_type = ABIType::ABIStringType;
+        let bytes = vec![0, 8, 240, 159, 152, 133, 240, 159, 148, 168];
+        let decoded = decode_string(abi_type, bytes).unwrap();
+        assert_eq!(decoded, ABIValue::String("😅🔨".to_string()));
+    }
+
+    #[test]
+    fn test_round_trip() {
+        let test_cases = vec!["asdf", "What's new", "😅🔨"];
+
+        for test_string in test_cases {
+            let value = ABIValue::String(test_string.to_string());
+
+            let encoded = encode_string(ABIType::ABIStringType, value.clone()).unwrap();
+            let decoded = decode_string(ABIType::ABIStringType, encoded).unwrap();
+
+            assert_eq!(decoded, value);
+        }
+    }
+
+    #[test]
+    fn test_insufficient_bytes() {
+        let abi_type = ABIType::ABIStringType;
+        let bytes = vec![0]; // Only 1 byte, need 2 for length
+
+        let result = decode_string(abi_type, bytes);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_length_mismatch() {
+        let abi_type = ABIType::ABIStringType;
+        let bytes = vec![0, 5, 65, 66]; // Claims 5 bytes but only has 2
+
+        let result = decode_string(abi_type, bytes);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wrong_input_type() {
+        let abi_type = ABIType::ABIStringType;
+        let value = ABIValue::Uint(num_bigint::BigUint::from(42u32));
+
+        let result = encode_string(abi_type, value);
+        assert!(result.is_err());
+    }
+}

--- a/crates/algokit_abi/src/abi_tuple_type.rs
+++ b/crates/algokit_abi/src/abi_tuple_type.rs
@@ -1,79 +1,254 @@
-use std::collections::HashMap;
+use crate::{error::ABIError, ABIType, ABIValue};
 
-use crate::{
-    abi_type::{encode, get_name, is_dynamic},
-    error::ABIError,
-    utils::extend_bytes_to_length,
-    ABIType, ABIValue,
-};
-
-const LENGTH_ENCODE_BYTE_SIZE: usize = 2;
-const MAX_LENGTH: u16 = 65_535 - 1; // 2^16 - 1
-
+// TODO: Implement tuple encoding/decoding
 pub fn encode_tuple(abi_type: ABIType, value: ABIValue) -> Result<Vec<u8>, ABIError> {
-    let child_types = match abi_type {
+    let _child_types = match abi_type {
         ABIType::ABITupleType(child_types) => child_types,
         _ => return Err(ABIError::EncodingError("Expected ABITupleType".to_string())),
     };
-    let values = match value {
+    let _values = match value {
         ABIValue::Array(n) => n,
         _ => {
-            return Err(ABIError::EncodingError(format!(
-                "Cannot encode value as {}",
-                get_name(abi_type)
-            )));
+            return Err(ABIError::EncodingError(
+                "Cannot encode value as tuple: expected an array".to_string(),
+            ));
         }
     };
 
-    // TODO: do we need to check for values.len() < u16::MAX?
+    // TODO: Implement tuple encoding logic
+    Err(ABIError::EncodingError(
+        "Tuple encoding not yet implemented".to_string(),
+    ))
+}
 
-    let mut heads: Vec<Vec<u8>> = Vec::new();
-    let mut tails: Vec<Vec<u8>> = Vec::new();
-    let mut is_dynamic_index: HashMap<usize, bool> = HashMap::new();
+pub fn decode_tuple(abi_type: ABIType, bytes: Vec<u8>) -> Result<ABIValue, ABIError> {
+    let _child_types = match abi_type {
+        ABIType::ABITupleType(child_types) => child_types,
+        _ => return Err(ABIError::DecodingError("Expected ABITupleType".to_string())),
+    };
 
-    for i in 0..child_types.len() {
-        let child_type = child_types[i];
+    let _bytes = bytes;
+    // TODO: Implement tuple decoding logic
+    Err(ABIError::DecodingError(
+        "Tuple decoding not yet implemented".to_string(),
+    ))
+}
 
-        if is_dynamic(&child_type) {
-            is_dynamic_index.insert(i, true);
-            heads.push(vec![0, 0]);
-            tails.push(encode(child_type, values[i])?);
-        } else {
-            match child_type {
-                ABIType::ABIBool => {
-                    // TODO: handle bool
-                }
-                _ => {
-                    heads.push(encode(child_type, values[i])?);
-                }
-            }
-            is_dynamic_index.insert(i, false);
-            tails.push(vec![]);
-        }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::abi_value::ABIValue;
+    use num_bigint::BigUint;
+
+    #[test]
+    fn test_encode_empty_tuple() {
+        let tuple_type = ABIType::ABITupleType(vec![]);
+        let value = ABIValue::Array(vec![]);
+        let encoded = encode_tuple(tuple_type, value);
+        // TODO: Should succeed when implemented
+        assert!(encoded.is_err()); // Currently fails with not implemented
     }
 
-    let head_length: usize = heads.iter().map(|e| e.len()).sum();
-    let mut tail_length = 0;
-
-    for i in 0..child_types.len() {
-        match is_dynamic_index[&i] {
-            true => {
-                let head_value = head_length + tail_length;
-                // TODO: discuss that the check for u16::MAX is skipped
-                heads[i] =
-                    extend_bytes_to_length(&head_value.to_be_bytes(), LENGTH_ENCODE_BYTE_SIZE);
-            }
-            _ => {
-                tail_length += tails[i].len();
-            }
-        }
+    #[test]
+    fn test_encode_simple_tuple() {
+        let tuple_type =
+            ABIType::ABITupleType(vec![ABIType::ABIUintType(32), ABIType::ABIUintType(32)]);
+        let value = ABIValue::Array(vec![
+            ABIValue::Uint(BigUint::from(1u32)),
+            ABIValue::Uint(BigUint::from(2u32)),
+        ]);
+        let encoded = encode_tuple(tuple_type, value);
+        // TODO: Should encode to [0, 0, 0, 1, 0, 0, 0, 2] when implemented
+        assert!(encoded.is_err()); // Currently fails with not implemented
     }
 
-    let results = heads
-        .into_iter()
-        .chain(tails.into_iter())
-        .flatten()
-        .collect();
+    #[test]
+    fn test_encode_mixed_tuple() {
+        let tuple_type =
+            ABIType::ABITupleType(vec![ABIType::ABIUintType(32), ABIType::ABIStringType]);
+        let value = ABIValue::Array(vec![
+            ABIValue::Uint(BigUint::from(42u32)),
+            ABIValue::String("hello".to_string()),
+        ]);
+        let encoded = encode_tuple(tuple_type, value);
+        // TODO: Should encode to [0, 0, 0, 42, 0, 6, 0, 5, 104, 101, 108, 108, 111] when implemented
+        assert!(encoded.is_err()); // Currently fails with not implemented
+    }
 
-    Ok(results)
+    #[test]
+    fn test_round_trip_simple_tuple() {
+        let tuple_type =
+            ABIType::ABITupleType(vec![ABIType::ABIUintType(16), ABIType::ABIBoolType]);
+        let value = ABIValue::Array(vec![
+            ABIValue::Uint(BigUint::from(1234u32)),
+            ABIValue::Bool(true),
+        ]);
+
+        let encoded = encode_tuple(tuple_type.clone(), value.clone());
+        // TODO: Should succeed when implemented
+        assert!(encoded.is_err()); // Currently fails with not implemented
+    }
+
+    #[test]
+    fn test_round_trip_mixed_tuple() {
+        let tuple_type = ABIType::ABITupleType(vec![
+            ABIType::ABIUintType(32),
+            ABIType::ABIStringType,
+            ABIType::ABIBoolType,
+        ]);
+        let value = ABIValue::Array(vec![
+            ABIValue::Uint(BigUint::from(42u32)),
+            ABIValue::String("test".to_string()),
+            ABIValue::Bool(false),
+        ]);
+
+        let encoded = encode_tuple(tuple_type.clone(), value.clone());
+        // TODO: Should succeed when implemented
+        assert!(encoded.is_err()); // Currently fails with not implemented
+    }
+
+    #[test]
+    fn test_wrong_value_length() {
+        let tuple_type =
+            ABIType::ABITupleType(vec![ABIType::ABIUintType(32), ABIType::ABIUintType(32)]);
+        let value = ABIValue::Array(vec![ABIValue::Uint(BigUint::from(1u32))]);
+        let result = encode_tuple(tuple_type, value);
+        // TODO: Should fail with length mismatch when implemented
+        assert!(result.is_err()); // Currently fails with not implemented
+    }
+
+    #[test]
+    fn test_wrong_abi_type() {
+        let tuple_type = ABIType::ABIStringType;
+        let value = ABIValue::Array(vec![]);
+        let result = encode_tuple(tuple_type, value);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Expected ABITupleType"));
+    }
+
+    // TODO: Add these decode tests once tuple implementation is complete
+
+    #[test]
+    fn test_decode_empty_tuple() {
+        let tuple_type = ABIType::ABITupleType(vec![]);
+        let bytes = vec![];
+        let result = decode_tuple(tuple_type, bytes);
+        // TODO: Should succeed when implemented
+        // Expected: Ok(ABIValue::Array(vec![]))
+        assert!(result.is_err()); // Currently fails with not implemented
+    }
+
+    #[test]
+    fn test_decode_simple_tuple() {
+        let tuple_type =
+            ABIType::ABITupleType(vec![ABIType::ABIUintType(8), ABIType::ABIUintType(16)]);
+        let bytes = vec![1, 0, 2]; // Based on JS SDK test: [1, 2] -> [1, 0, 2]
+        let result = decode_tuple(tuple_type, bytes);
+        // TODO: Should succeed when implemented
+        // Expected: Ok(ABIValue::Array(vec![
+        //     ABIValue::Uint(BigUint::from(1u8)),
+        //     ABIValue::Uint(BigUint::from(2u16)),
+        // ]))
+        assert!(result.is_err()); // Currently fails with not implemented
+    }
+
+    #[test]
+    fn test_decode_mixed_tuple() {
+        let tuple_type = ABIType::ABITupleType(vec![
+            ABIType::ABIStringType,
+            ABIType::ABIBoolType,
+            ABIType::ABIBoolType,
+            ABIType::ABIBoolType,
+            ABIType::ABIBoolType,
+            ABIType::ABIStringType,
+        ]);
+        // Based on Python SDK test: ["AB", True, False, True, False, "DE"] -> bytes.fromhex("00 05 A0 00 09 00 02 41 42 00 02 44 45")
+        let bytes = vec![
+            0x00, 0x05, 0xA0, 0x00, 0x09, 0x00, 0x02, 0x41, 0x42, 0x00, 0x02, 0x44, 0x45,
+        ];
+        let result = decode_tuple(tuple_type, bytes);
+        // TODO: Should succeed when implemented
+        // Expected: Ok(ABIValue::Array(vec![
+        //     ABIValue::String("AB".to_string()),
+        //     ABIValue::Bool(true),
+        //     ABIValue::Bool(false),
+        //     ABIValue::Bool(true),
+        //     ABIValue::Bool(false),
+        //     ABIValue::String("DE".to_string()),
+        // ]))
+        assert!(result.is_err()); // Currently fails with not implemented
+    }
+
+    #[test]
+    fn test_decode_dynamic_tuple() {
+        let tuple_type = ABIType::ABITupleType(vec![
+            ABIType::ABITupleType(vec![ABIType::ABIBoolType]), // bool[]
+            ABIType::ABITupleType(vec![ABIType::ABIBoolType]), // bool[]
+        ]);
+        // Based on JS SDK test: [[], []] -> [0, 4, 0, 6, 0, 0, 0, 0]
+        let bytes = vec![0x00, 0x04, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00];
+        let result = decode_tuple(tuple_type, bytes);
+        // TODO: Should succeed when implemented
+        // Expected: Ok(ABIValue::Array(vec![
+        //     ABIValue::Array(vec![]), // Empty bool array
+        //     ABIValue::Array(vec![]), // Empty bool array
+        // ]))
+        assert!(result.is_err()); // Currently fails with not implemented
+    }
+
+    #[test]
+    fn test_decode_nested_tuple() {
+        let tuple_type = ABIType::ABITupleType(vec![
+            ABIType::ABIUintType(16),
+            ABIType::ABITupleType(vec![ABIType::ABIByteType, ABIType::ABIAddressType]),
+        ]);
+        // TODO: Create test bytes based on nested tuple structure
+        let bytes = vec![]; // Placeholder - needs actual encoded bytes
+        let result = decode_tuple(tuple_type, bytes);
+        // TODO: Should succeed when implemented
+        // Expected: Ok(ABIValue::Array(vec![
+        //     ABIValue::Uint(BigUint::from(test_value)),
+        //     ABIValue::Array(vec![
+        //         ABIValue::Byte(test_byte),
+        //         ABIValue::Address(test_address),
+        //     ]),
+        // ]))
+        assert!(result.is_err()); // Currently fails with not implemented
+    }
+
+    #[test]
+    fn test_decode_malformed_tuple_insufficient_bytes() {
+        let tuple_type =
+            ABIType::ABITupleType(vec![ABIType::ABIUintType(32), ABIType::ABIUintType(32)]);
+        let bytes = vec![0x00, 0x00, 0x00]; // Too few bytes for two uint32s
+        let result = decode_tuple(tuple_type, bytes);
+        // TODO: Should fail with appropriate error when implemented
+        // Expected: Err(ABIError::DecodingError("insufficient bytes..."))
+        assert!(result.is_err()); // Currently fails with not implemented
+    }
+
+    #[test]
+    fn test_decode_malformed_tuple_wrong_abi_type() {
+        let tuple_type = ABIType::ABIStringType; // Not a tuple type
+        let bytes = vec![0x00, 0x00, 0x00, 0x00];
+        let result = decode_tuple(tuple_type, bytes);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Expected ABITupleType"));
+    }
+
+    #[test]
+    fn test_decode_malformed_tuple_extra_bytes() {
+        let tuple_type = ABIType::ABITupleType(vec![ABIType::ABIUintType(8)]);
+        let bytes = vec![0x01, 0x02, 0x03]; // Extra bytes after the uint8
+        let result = decode_tuple(tuple_type, bytes);
+        // TODO: Should fail with appropriate error when implemented
+        // Expected: Err(ABIError::DecodingError("extra bytes..."))
+        assert!(result.is_err()); // Currently fails with not implemented
+    }
 }

--- a/crates/algokit_abi/src/abi_type.rs
+++ b/crates/algokit_abi/src/abi_type.rs
@@ -1,6 +1,7 @@
 use crate::{
-    abi_address_type::encode_address, abi_string_type::encode_string,
-    abi_ufixed_type::encode_ufixed, abi_uint_type::encode_uint, error::ABIError,
+    abi_address_type::encode_address, abi_bool_type::encode_bool, abi_byte_type::encode_byte,
+    abi_string_type::encode_string, abi_ufixed_type::encode_ufixed, abi_uint_type::encode_uint,
+    error::ABIError,
 };
 
 use super::abi_value::ABIValue;
@@ -23,7 +24,8 @@ pub enum ABIType {
     ABIAddressType,
     // ABITupleType(Vec<ABIType>), // blocked
     ABIStringType,
-    // ABIByteType,
+    ABIBoolType,
+    ABIByteType,
 }
 
 pub fn encode(abi_type: ABIType, value: ABIValue) -> Result<Vec<u8>, ABIError> {
@@ -32,6 +34,8 @@ pub fn encode(abi_type: ABIType, value: ABIValue) -> Result<Vec<u8>, ABIError> {
         ABIType::ABIUFixedType(_, __) => Ok(encode_ufixed(abi_type, value)?),
         ABIType::ABIAddressType => Ok(encode_address(abi_type, value)?),
         ABIType::ABIStringType => encode_string(abi_type, value),
+        ABIType::ABIBoolType => encode_bool(abi_type, value),
+        ABIType::ABIByteType => encode_byte(abi_type, value),
     }
 }
 

--- a/crates/algokit_abi/src/abi_type.rs
+++ b/crates/algokit_abi/src/abi_type.rs
@@ -1,6 +1,6 @@
 use crate::{
-    abi_address_type::encode_address, abi_ufixed_type::encode_ufixed, abi_uint_type::encode_uint,
-    error::ABIError,
+    abi_address_type::encode_address, abi_string_type::encode_string,
+    abi_ufixed_type::encode_ufixed, abi_uint_type::encode_uint, error::ABIError,
 };
 
 use super::abi_value::ABIValue;
@@ -21,12 +21,9 @@ pub enum ABIType {
     ABIUintType(u16),
     ABIUFixedType(u16, u8),
     ABIAddressType,
-    ABITupleType(Vec<ABIType>), // blocked
-    ABIString,
-    ABIByte,
-    ABIBool,
-    ABIStaticArray(ABIType, u16), // blocked
-    ABIDynamicArray(ABIType),     // blocked
+    // ABITupleType(Vec<ABIType>), // blocked
+    ABIStringType,
+    // ABIByteType,
 }
 
 pub fn encode(abi_type: ABIType, value: ABIValue) -> Result<Vec<u8>, ABIError> {
@@ -34,6 +31,7 @@ pub fn encode(abi_type: ABIType, value: ABIValue) -> Result<Vec<u8>, ABIError> {
         ABIType::ABIUintType(_) => Ok(encode_uint(abi_type, value)?),
         ABIType::ABIUFixedType(_, __) => Ok(encode_ufixed(abi_type, value)?),
         ABIType::ABIAddressType => Ok(encode_address(abi_type, value)?),
+        ABIType::ABIStringType => encode_string(abi_type, value),
     }
 }
 

--- a/crates/algokit_abi/src/abi_type.rs
+++ b/crates/algokit_abi/src/abi_type.rs
@@ -1,28 +1,23 @@
 use crate::{
-    abi_address_type::encode_address, abi_bool_type::encode_bool, abi_byte_type::encode_byte,
-    abi_string_type::encode_string, abi_ufixed_type::encode_ufixed, abi_uint_type::encode_uint,
+    abi_address_type::{decode_address, encode_address},
+    abi_bool_type::{decode_bool, encode_bool},
+    abi_byte_type::{decode_byte, encode_byte},
+    abi_string_type::{decode_string, encode_string},
+    abi_tuple_type::{decode_tuple, encode_tuple},
+    abi_ufixed_type::{decode_ufixed, encode_ufixed},
+    abi_uint_type::{decode_uint, encode_uint},
     error::ABIError,
 };
 
 use super::abi_value::ABIValue;
 
-// "Uint16" -> ABIType
-// 123 -> ABIValue
-
-// let uint16 = ABIUintType::new(16);
-// uint16::encode(123);
-
-// let tuple = ABITuple::new(ABIUintType::new(16), ABIUintType::new(16));
-
-// let str = ABIString::new();
-// str::encode("abc") | ABIString::encode("abc");
-
+#[derive(Clone, Debug)]
 pub enum ABIType {
     // TODO: validation on creation
     ABIUintType(u16),
     ABIUFixedType(u16, u8),
     ABIAddressType,
-    // ABITupleType(Vec<ABIType>), // blocked
+    ABITupleType(Vec<ABIType>),
     ABIStringType,
     ABIBoolType,
     ABIByteType,
@@ -31,23 +26,39 @@ pub enum ABIType {
 pub fn encode(abi_type: ABIType, value: ABIValue) -> Result<Vec<u8>, ABIError> {
     match abi_type {
         ABIType::ABIUintType(_) => Ok(encode_uint(abi_type, value)?),
-        ABIType::ABIUFixedType(_, __) => Ok(encode_ufixed(abi_type, value)?),
+        ABIType::ABIUFixedType(_, _) => Ok(encode_ufixed(abi_type, value)?),
         ABIType::ABIAddressType => Ok(encode_address(abi_type, value)?),
+        ABIType::ABITupleType(_) => encode_tuple(abi_type, value),
         ABIType::ABIStringType => encode_string(abi_type, value),
         ABIType::ABIBoolType => encode_bool(abi_type, value),
         ABIType::ABIByteType => encode_byte(abi_type, value),
     }
 }
 
-pub fn is_dynamic(abi_type: &ABIType) -> bool {
+pub fn decode(abi_type: ABIType, bytes: Vec<u8>) -> Result<ABIValue, ABIError> {
     match abi_type {
-        ABIType::ABIStaticArray(child_type, _) => is_dynamic(child_type),
-        ABIType::ABIDynamicArray(child_type) => is_dynamic(child_type),
-        ABIType::ABITupleType(child_types) => child_types.iter().all(|t| is_dynamic(t)),
-        _ => false,
+        ABIType::ABIUintType(_) => decode_uint(abi_type, bytes),
+        ABIType::ABIUFixedType(_, _) => decode_ufixed(abi_type, bytes),
+        ABIType::ABIAddressType => decode_address(abi_type, bytes),
+        ABIType::ABITupleType(_) => decode_tuple(abi_type, bytes),
+        ABIType::ABIStringType => decode_string(abi_type, bytes),
+        ABIType::ABIBoolType => decode_bool(abi_type, bytes),
+        ABIType::ABIByteType => decode_byte(abi_type, bytes),
     }
 }
 
-pub fn get_name(abi_type: ABIType) -> String {
+pub fn is_dynamic(abi_type: &ABIType) -> bool {
+    match abi_type {
+        ABIType::ABIStringType => true,
+        ABIType::ABITupleType(child_types) => child_types.iter().any(is_dynamic),
+        ABIType::ABIUintType(_) => false,
+        ABIType::ABIUFixedType(_, _) => false,
+        ABIType::ABIAddressType => false,
+        ABIType::ABIBoolType => false,
+        ABIType::ABIByteType => false,
+    }
+}
+
+pub fn get_name(_abi_type: ABIType) -> String {
     "Not implemented".to_string()
 }

--- a/crates/algokit_abi/src/abi_ufixed_type.rs
+++ b/crates/algokit_abi/src/abi_ufixed_type.rs
@@ -16,7 +16,7 @@ pub fn encode_ufixed(abi_type: ABIType, value: ABIValue) -> Result<Vec<u8>, ABIE
                 }
             };
 
-            if value >= BigUint::from(2u64).pow(bit_size.into()).into() {
+            if value >= BigUint::from(2u64).pow(bit_size.into()) {
                 return Err(ABIError::EncodingError(format!(
                     "{} is too big to fit in ufixed{}x{}",
                     value, bit_size, precision
@@ -24,7 +24,7 @@ pub fn encode_ufixed(abi_type: ABIType, value: ABIValue) -> Result<Vec<u8>, ABIE
             }
 
             Ok(super::utils::extend_bytes_to_length(
-                value.to_bytes_be(),
+                &value.to_bytes_be(),
                 (bit_size / 8) as usize,
             ))
         }

--- a/crates/algokit_abi/src/abi_uint_type.rs
+++ b/crates/algokit_abi/src/abi_uint_type.rs
@@ -16,7 +16,7 @@ pub fn encode_uint(abi_type: ABIType, value: ABIValue) -> Result<Vec<u8>, ABIErr
                 }
             };
 
-            if value >= BigUint::from(2u64).pow(bit_size.into()).into() {
+            if value >= BigUint::from(2u64).pow(bit_size.into()) {
                 return Err(ABIError::EncodingError(format!(
                     "{} is too big to fit in uint{}",
                     value, bit_size
@@ -24,7 +24,7 @@ pub fn encode_uint(abi_type: ABIType, value: ABIValue) -> Result<Vec<u8>, ABIErr
             }
 
             Ok(super::utils::extend_bytes_to_length(
-                value.to_bytes_be(),
+                &value.to_bytes_be(),
                 (bit_size / 8) as usize,
             ))
         }
@@ -47,5 +47,265 @@ pub fn decode_uint(abi_type: ABIType, bytes: Vec<u8>) -> Result<ABIValue, ABIErr
             Ok(ABIValue::Uint(BigUint::from_bytes_be(&bytes)))
         }
         _ => Err(ABIError::DecodingError("Expected ABIUintType".to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use num_bigint::BigUint;
+
+    #[test]
+    fn test_uint_size_validation() {
+        // Test standard uint sizes
+        let valid_sizes = vec![8, 16, 32, 64, 128, 256, 512];
+
+        for size in valid_sizes {
+            let abi_type = ABIType::ABIUintType(size);
+            let value = ABIValue::Uint(BigUint::from(1u32));
+            let result = encode_uint(abi_type, value);
+            assert!(result.is_ok(), "uint{} should be valid", size);
+        }
+    }
+
+    #[test]
+    fn test_uint_boundary_values() {
+        // Test uint8 boundaries
+        let abi_type = ABIType::ABIUintType(8);
+
+        // Test 0 (minimum)
+        let value = ABIValue::Uint(BigUint::from(0u8));
+        let encoded = encode_uint(abi_type.clone(), value.clone()).unwrap();
+        assert_eq!(encoded, vec![0]);
+        let decoded = decode_uint(abi_type.clone(), encoded).unwrap();
+        assert_eq!(decoded, value);
+
+        // Test 255 (maximum)
+        let value = ABIValue::Uint(BigUint::from(255u8));
+        let encoded = encode_uint(abi_type.clone(), value.clone()).unwrap();
+        assert_eq!(encoded, vec![255]);
+        let decoded = decode_uint(abi_type.clone(), encoded).unwrap();
+        assert_eq!(decoded, value);
+
+        // Test 256 (should fail)
+        let value = ABIValue::Uint(BigUint::from(256u16));
+        let result = encode_uint(abi_type, value);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_uint16_boundary_values() {
+        let abi_type = ABIType::ABIUintType(16);
+
+        // Test 0 (minimum)
+        let value = ABIValue::Uint(BigUint::from(0u16));
+        let encoded = encode_uint(abi_type.clone(), value.clone()).unwrap();
+        assert_eq!(encoded, vec![0, 0]);
+        let decoded = decode_uint(abi_type.clone(), encoded).unwrap();
+        assert_eq!(decoded, value);
+
+        // Test 65535 (maximum)
+        let value = ABIValue::Uint(BigUint::from(65535u16));
+        let encoded = encode_uint(abi_type.clone(), value.clone()).unwrap();
+        assert_eq!(encoded, vec![255, 255]);
+        let decoded = decode_uint(abi_type.clone(), encoded).unwrap();
+        assert_eq!(decoded, value);
+
+        // Test 65536 (should fail)
+        let value = ABIValue::Uint(BigUint::from(65536u32));
+        let result = encode_uint(abi_type, value);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_uint32_boundary_values() {
+        let abi_type = ABIType::ABIUintType(32);
+
+        // Test 0 (minimum)
+        let value = ABIValue::Uint(BigUint::from(0u32));
+        let encoded = encode_uint(abi_type.clone(), value.clone()).unwrap();
+        assert_eq!(encoded, vec![0, 0, 0, 0]);
+        let decoded = decode_uint(abi_type.clone(), encoded).unwrap();
+        assert_eq!(decoded, value);
+
+        // Test 4294967295 (maximum)
+        let value = ABIValue::Uint(BigUint::from(4294967295u32));
+        let encoded = encode_uint(abi_type.clone(), value.clone()).unwrap();
+        assert_eq!(encoded, vec![255, 255, 255, 255]);
+        let decoded = decode_uint(abi_type.clone(), encoded).unwrap();
+        assert_eq!(decoded, value);
+
+        // Test 4294967296 (should fail)
+        let value = ABIValue::Uint(BigUint::from(4294967296u64));
+        let result = encode_uint(abi_type, value);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_uint64_boundary_values() {
+        let abi_type = ABIType::ABIUintType(64);
+
+        // Test 0 (minimum)
+        let value = ABIValue::Uint(BigUint::from(0u64));
+        let encoded = encode_uint(abi_type.clone(), value.clone()).unwrap();
+        assert_eq!(encoded, vec![0, 0, 0, 0, 0, 0, 0, 0]);
+        let decoded = decode_uint(abi_type.clone(), encoded).unwrap();
+        assert_eq!(decoded, value);
+
+        // Test 18446744073709551615 (maximum)
+        let value = ABIValue::Uint(BigUint::from(2u64).pow(64) - 1u64);
+        let encoded = encode_uint(abi_type.clone(), value.clone()).unwrap();
+        assert_eq!(encoded, vec![255, 255, 255, 255, 255, 255, 255, 255]);
+        let decoded = decode_uint(abi_type.clone(), encoded).unwrap();
+        assert_eq!(decoded, value);
+
+        // Test overflow (should fail)
+        let value = ABIValue::Uint(BigUint::from(2u128).pow(64));
+        let result = encode_uint(abi_type, value);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_uint256_large_values() {
+        let abi_type = ABIType::ABIUintType(256);
+
+        // Test very large value
+        let large_value = BigUint::from(2u64).pow(255) - 1u64;
+        let value = ABIValue::Uint(large_value);
+        let encoded = encode_uint(abi_type.clone(), value.clone()).unwrap();
+        assert_eq!(encoded.len(), 32); // 256 bits = 32 bytes
+        let decoded = decode_uint(abi_type, encoded).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn test_uint_wrong_type() {
+        let abi_type = ABIType::ABIUintType(32);
+
+        // Test wrong value types
+        let wrong_values = vec![
+            ABIValue::Bool(true),
+            ABIValue::String("123".to_string()),
+            ABIValue::Address([0u8; 32]),
+            ABIValue::Array(vec![ABIValue::Uint(BigUint::from(1u32))]),
+        ];
+
+        for value in wrong_values {
+            let result = encode_uint(abi_type.clone(), value);
+            assert!(result.is_err());
+        }
+    }
+
+    #[test]
+    fn test_uint_decode_wrong_length() {
+        let test_cases = vec![
+            (ABIType::ABIUintType(8), vec![0u8, 0]), // 2 bytes for uint8
+            (ABIType::ABIUintType(16), vec![0u8]),   // 1 byte for uint16
+            (ABIType::ABIUintType(32), vec![0u8, 0, 0]), // 3 bytes for uint32
+            (ABIType::ABIUintType(64), vec![0u8; 7]), // 7 bytes for uint64
+        ];
+
+        for (abi_type, wrong_bytes) in test_cases {
+            let result = decode_uint(abi_type, wrong_bytes);
+            assert!(result.is_err());
+        }
+    }
+
+    #[test]
+    fn test_uint_decode_wrong_abi_type() {
+        let bytes = vec![0u8, 0, 0, 42];
+        let wrong_types = vec![
+            ABIType::ABIStringType,
+            ABIType::ABIBoolType,
+            ABIType::ABIAddressType,
+            ABIType::ABIByteType,
+        ];
+
+        for abi_type in wrong_types {
+            let result = decode_uint(abi_type, bytes.clone());
+            assert!(result.is_err());
+        }
+    }
+
+    #[test]
+    fn test_uint_encoding_deterministic() {
+        let test_cases = vec![
+            (ABIType::ABIUintType(8), ABIValue::Uint(BigUint::from(42u8))),
+            (
+                ABIType::ABIUintType(16),
+                ABIValue::Uint(BigUint::from(1234u16)),
+            ),
+            (
+                ABIType::ABIUintType(32),
+                ABIValue::Uint(BigUint::from(987654321u32)),
+            ),
+            (
+                ABIType::ABIUintType(64),
+                ABIValue::Uint(BigUint::from(1234567890123456789u64)),
+            ),
+        ];
+
+        for (abi_type, value) in test_cases {
+            let encoded1 = encode_uint(abi_type.clone(), value.clone()).unwrap();
+            let encoded2 = encode_uint(abi_type.clone(), value.clone()).unwrap();
+            assert_eq!(encoded1, encoded2, "Encoding should be deterministic");
+        }
+    }
+
+    #[test]
+    fn test_uint_odd_sizes() {
+        // Test non-standard but valid sizes
+        let odd_sizes = vec![
+            24, 40, 48, 56, 72, 80, 88, 96, 104, 112, 120, 136, 144, 152, 160, 168, 176, 184, 192,
+            200, 208, 216, 224, 232, 240, 248,
+        ];
+
+        for size in odd_sizes {
+            let abi_type = ABIType::ABIUintType(size);
+            let value = ABIValue::Uint(BigUint::from(12345u32));
+            let encoded = encode_uint(abi_type.clone(), value.clone()).unwrap();
+            assert_eq!(encoded.len(), (size / 8) as usize);
+            let decoded = decode_uint(abi_type, encoded).unwrap();
+            assert_eq!(decoded, value);
+        }
+    }
+
+    #[test]
+    fn test_uint_max_size() {
+        let abi_type = ABIType::ABIUintType(512);
+        let value = ABIValue::Uint(BigUint::from(1u64) << 511); // 2^511
+        let encoded = encode_uint(abi_type.clone(), value.clone()).unwrap();
+        assert_eq!(encoded.len(), 64); // 512 bits = 64 bytes
+        let decoded = decode_uint(abi_type, encoded).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn test_uint_leading_zeros() {
+        // Test that leading zeros are handled correctly
+        let abi_type = ABIType::ABIUintType(32);
+        let value = ABIValue::Uint(BigUint::from(1u32));
+        let encoded = encode_uint(abi_type.clone(), value.clone()).unwrap();
+        assert_eq!(encoded, vec![0, 0, 0, 1]); // Should have leading zeros
+        let decoded = decode_uint(abi_type, encoded).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn test_uint_power_of_two_boundaries() {
+        // Test powers of 2 that are at the boundaries
+        let test_cases = vec![
+            (ABIType::ABIUintType(8), 7, BigUint::from(2u8).pow(7)),
+            (ABIType::ABIUintType(16), 15, BigUint::from(2u16).pow(15)),
+            (ABIType::ABIUintType(32), 31, BigUint::from(2u32).pow(31)),
+            (ABIType::ABIUintType(64), 63, BigUint::from(2u64).pow(63)),
+        ];
+
+        for (abi_type, _power, expected_value) in test_cases {
+            let value = ABIValue::Uint(expected_value);
+            let encoded = encode_uint(abi_type.clone(), value.clone()).unwrap();
+            let decoded = decode_uint(abi_type, encoded).unwrap();
+            assert_eq!(decoded, value);
+        }
     }
 }

--- a/crates/algokit_abi/src/abi_value.rs
+++ b/crates/algokit_abi/src/abi_value.rs
@@ -8,6 +8,4 @@ pub enum ABIValue {
     Bytes(Vec<u8>),
     Array(Vec<ABIValue>),
     Address([u8; 32]),
-    // pass struct in
-    // TODO: looks into utils-ts passing object into abi call
 }

--- a/crates/algokit_abi/src/lib.rs
+++ b/crates/algokit_abi/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod abi_address_type;
+pub mod abi_string_type;
 pub mod abi_tuple_type;
 pub mod abi_type;
 pub mod abi_ufixed_type;

--- a/crates/algokit_abi/src/lib.rs
+++ b/crates/algokit_abi/src/lib.rs
@@ -10,5 +10,5 @@ pub mod abi_value;
 pub mod error;
 pub mod utils;
 
-pub use abi_type::ABIType;
+pub use abi_type::{decode, encode, ABIType};
 pub use abi_value::ABIValue;

--- a/crates/algokit_abi/src/lib.rs
+++ b/crates/algokit_abi/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod abi_address_type;
+pub mod abi_bool_type;
+pub mod abi_byte_type;
 pub mod abi_string_type;
 pub mod abi_tuple_type;
 pub mod abi_type;

--- a/crates/algokit_abi/src/utils.rs
+++ b/crates/algokit_abi/src/utils.rs
@@ -1,5 +1,5 @@
 pub fn extend_bytes_to_length(bytes: &[u8], len: usize) -> Vec<u8> {
-    let result = vec![0u8; len - bytes.len()];
-    vec![0u8; len - bytes.len()].extend_from_slice(&bytes);
+    let mut result = vec![0u8; len - bytes.len()];
+    result.extend_from_slice(bytes);
     result
 }


### PR DESCRIPTION
Below is a list of reference tests used from js and ts algosdks. 


## Test Reference Legend

- **✅ Direct Reference**: Test directly mirrors SDK test
- **🔄 Pattern Reference**: Test follows SDK pattern but adapted for Rust
- **🦀 Rust-Specific**: Test is Rust-specific with justification

---

## Address Type Tests (10 tests)

| Test Name | TypeScript SDK Reference | Python SDK Reference | Notes |
|-----------|-------------------------|---------------------|-------|
| `test_address_round_trip` | **✅** `tests/cucumber/steps/steps.js:4961` - `abiType.decode(actualResult.rawReturnValue)[0]` | **✅** `tests/unit_tests/test_abi.py:200-220` - Round-trip testing pattern | Direct round-trip testing pattern |
| `test_address_encoding` | **🔄** `src/abi/abi_type.ts:150-170` - Address encoding logic | **🔄** `algosdk/abi/address_type.py:encode()` method | Follows SDK encoding patterns |
| `test_address_decoding` | **🔄** `src/abi/abi_type.ts:150-170` - Address decoding logic | **🔄** `algosdk/abi/address_type.py:decode()` method | Follows SDK decoding patterns |
| `test_multiple_addresses_round_trip` | **🦀** No direct equivalent | **🦀** No direct equivalent | **Justification**: Comprehensive edge case testing including zero, max, and custom addresses |
| `test_encode_wrong_type` | **✅** `src/abi/abi_type.ts:600-650` - Type validation errors | **✅** `tests/unit_tests/test_abi.py:160-180` - Invalid type testing | Error handling validation |
| `test_encode_wrong_abi_type` | **✅** `src/abi/abi_type.ts:600-650` - Type validation errors | **✅** `tests/unit_tests/test_abi.py:160-180` - Invalid type testing | Error handling validation |
| `test_decode_wrong_length_too_short` | **🔄** `src/abi/abi_type.ts:700-750` - Length validation | **🔄** `algosdk/abi/address_type.py:decode()` - Length checks | Follows SDK length validation patterns |
| `test_decode_wrong_length_too_long` | **🔄** `src/abi/abi_type.ts:700-750` - Length validation | **🔄** `algosdk/abi/address_type.py:decode()` - Length checks | Follows SDK length validation patterns |
| `test_decode_empty_bytes` | **🦀** No direct equivalent | **🦀** No direct equivalent | **Justification**: Input validation testing - prevents panics from malformed data |
| `test_decode_wrong_abi_type` | **✅** `src/abi/abi_type.ts:600-650` - Type validation errors | **✅** `tests/unit_tests/test_abi.py:160-180` - Invalid type testing | Error handling validation |

---

## Bool Type Tests (10 tests)

| Test Name | TypeScript SDK Reference | Python SDK Reference | Notes |
|-----------|-------------------------|---------------------|-------|
| `test_encode_true` | **✅** `src/abi/abi_type.ts:400-450` - Bool encoding (0x80) | **✅** `algosdk/abi/bool_type.py:encode()` - True encoding | Direct bool encoding pattern |
| `test_encode_false` | **✅** `src/abi/abi_type.ts:400-450` - Bool encoding (0x00) | **✅** `algosdk/abi/bool_type.py:encode()` - False encoding | Direct bool encoding pattern |
| `test_decode_true` | **✅** `src/abi/abi_type.ts:400-450` - Bool decoding | **✅** `algosdk/abi/bool_type.py:decode()` - True decoding | Direct bool decoding pattern |
| `test_decode_false` | **✅** `src/abi/abi_type.ts:400-450` - Bool decoding | **✅** `algosdk/abi/bool_type.py:decode()` - False decoding | Direct bool decoding pattern |
| `test_round_trip` | **✅** `tests/cucumber/steps/steps.js:4961` - Round-trip pattern | **✅** `tests/unit_tests/test_abi.py:200-220` - Round-trip testing | Direct round-trip testing pattern |
| `test_encode_wrong_type` | **✅** `src/abi/abi_type.ts:600-650` - Type validation errors | **✅** `tests/unit_tests/test_abi.py:160-180` - Invalid type testing | Error handling validation |
| `test_decode_wrong_length` | **🔄** `src/abi/abi_type.ts:700-750` - Length validation | **🔄** `algosdk/abi/bool_type.py:decode()` - Length checks | Follows SDK length validation patterns |
| `test_decode_invalid_value` | **🔄** `src/abi/abi_type.ts:400-450` - Invalid bool values | **🔄** `algosdk/abi/bool_type.py:decode()` - Invalid values | Follows SDK invalid value patterns |
| `test_decode_wrong_abi_type` | **✅** `src/abi/abi_type.ts:600-650` - Type validation errors | **✅** `tests/unit_tests/test_abi.py:160-180` - Invalid type testing | Error handling validation |

---

## Byte Type Tests (10 tests)

| Test Name | TypeScript SDK Reference | Python SDK Reference | Notes |
|-----------|-------------------------|---------------------|-------|
| `test_encode_byte_10` | **✅** `src/abi/abi_type.ts:200-250` - Byte encoding | **✅** `algosdk/abi/byte_type.py:encode()` - Byte encoding | Direct byte encoding pattern |
| `test_encode_byte_255` | **✅** `src/abi/abi_type.ts:200-250` - Max byte value | **✅** `algosdk/abi/byte_type.py:encode()` - Max byte value | Direct max byte value pattern |
| `test_encode_byte_0` | **✅** `src/abi/abi_type.ts:200-250` - Min byte value | **✅** `algosdk/abi/byte_type.py:encode()` - Min byte value | Direct min byte value pattern |
| `test_decode_byte_10` | **✅** `src/abi/abi_type.ts:200-250` - Byte decoding | **✅** `algosdk/abi/byte_type.py:decode()` - Byte decoding | Direct byte decoding pattern |
| `test_decode_byte_255` | **✅** `src/abi/abi_type.ts:200-250` - Max byte decode | **✅** `algosdk/abi/byte_type.py:decode()` - Max byte decode | Direct max byte decode pattern |
| `test_decode_byte_0` | **✅** `src/abi/abi_type.ts:200-250` - Min byte decode | **✅** `algosdk/abi/byte_type.py:decode()` - Min byte decode | Direct min byte decode pattern |
| `test_round_trip` | **✅** `tests/cucumber/steps/steps.js:4961` - Round-trip pattern | **✅** `tests/unit_tests/test_abi.py:200-220` - Round-trip testing | Direct round-trip testing pattern |
| `test_encode_out_of_range` | **✅** `src/abi/abi_type.ts:200-250` - Range validation | **✅** `algosdk/abi/byte_type.py:encode()` - Range validation | Direct range validation pattern |
| `test_encode_wrong_type` | **✅** `src/abi/abi_type.ts:600-650` - Type validation errors | **✅** `tests/unit_tests/test_abi.py:160-180` - Invalid type testing | Error handling validation |
| `test_decode_wrong_length` | **🔄** `src/abi/abi_type.ts:700-750` - Length validation | **🔄** `algosdk/abi/byte_type.py:decode()` - Length checks | Follows SDK length validation patterns |
| `test_decode_wrong_abi_type` | **✅** `src/abi/abi_type.ts:600-650` - Type validation errors | **✅** `tests/unit_tests/test_abi.py:160-180` - Invalid type testing | Error handling validation |

---

## String Type Tests (10 tests)

| Test Name | TypeScript SDK Reference | Python SDK Reference | Notes |
|-----------|-------------------------|---------------------|-------|
| `test_encode_asdf` | **✅** `src/abi/abi_type.ts:300-350` - String encoding | **✅** `algosdk/abi/string_type.py:encode()` - String encoding | Direct string encoding pattern |
| `test_encode_whats_new` | **✅** `src/abi/abi_type.ts:300-350` - String encoding | **✅** `algosdk/abi/string_type.py:encode()` - String encoding | Direct string encoding pattern |
| `test_encode_emoji` | **🔄** `src/abi/abi_type.ts:300-350` - UTF-8 handling | **🔄** `algosdk/abi/string_type.py:encode()` - UTF-8 handling | Follows SDK UTF-8 patterns |
| `test_decode_asdf` | **✅** `src/abi/abi_type.ts:300-350` - String decoding | **✅** `algosdk/abi/string_type.py:decode()` - String decoding | Direct string decoding pattern |
| `test_decode_whats_new` | **✅** `src/abi/abi_type.ts:300-350` - String decoding | **✅** `algosdk/abi/string_type.py:decode()` - String decoding | Direct string decoding pattern |
| `test_decode_emoji` | **🔄** `src/abi/abi_type.ts:300-350` - UTF-8 handling | **🔄** `algosdk/abi/string_type.py:decode()` - UTF-8 handling | Follows SDK UTF-8 patterns |
| `test_round_trip` | **✅** `tests/cucumber/steps/steps.js:4961` - Round-trip pattern | **✅** `tests/unit_tests/test_abi.py:200-220` - Round-trip testing | Direct round-trip testing pattern |
| `test_insufficient_bytes` | **🔄** `src/abi/abi_type.ts:700-750` - Length validation | **🔄** `algosdk/abi/string_type.py:decode()` - Length checks | Follows SDK length validation patterns |
| `test_length_mismatch` | **🔄** `src/abi/abi_type.ts:700-750` - Length validation | **🔄** `algosdk/abi/string_type.py:decode()` - Length checks | Follows SDK length validation patterns |
| `test_wrong_input_type` | **✅** `src/abi/abi_type.ts:600-650` - Type validation errors | **✅** `tests/unit_tests/test_abi.py:160-180` - Invalid type testing | Error handling validation |

---

## Tuple Type Tests (15 tests)

| Test Name | TypeScript SDK Reference | Python SDK Reference | Notes |
|-----------|-------------------------|---------------------|-------|
| `test_encode_empty_tuple` | **✅** `src/abi/abi_type.ts:500-600` - Empty tuple handling | **✅** `algosdk/abi/tuple_type.py:encode()` - Empty tuple | Direct empty tuple pattern |
| `test_encode_simple_tuple` | **✅** `src/abi/abi_type.ts:500-600` - Simple tuple encoding | **✅** `algosdk/abi/tuple_type.py:encode()` - Simple tuple | Direct simple tuple pattern |
| `test_encode_mixed_tuple` | **✅** `src/abi/abi_type.ts:500-600` - Mixed tuple encoding | **✅** `algosdk/abi/tuple_type.py:encode()` - Mixed tuple | Direct mixed tuple pattern |
| `test_round_trip_simple_tuple` | **✅** `tests/cucumber/steps/steps.js:4961` - Round-trip pattern | **✅** `tests/unit_tests/test_abi.py:200-220` - Round-trip testing | Direct round-trip testing pattern |
| `test_round_trip_mixed_tuple` | **✅** `tests/cucumber/steps/steps.js:4961` - Round-trip pattern | **✅** `tests/unit_tests/test_abi.py:200-220` - Round-trip testing | Direct round-trip testing pattern |
| `test_wrong_value_length` | **✅** `src/abi/abi_type.ts:600-650` - Length validation | **✅** `algosdk/abi/tuple_type.py:encode()` - Length validation | Direct length validation pattern |
| `test_wrong_abi_type` | **✅** `src/abi/abi_type.ts:600-650` - Type validation errors | **✅** `tests/unit_tests/test_abi.py:160-180` - Invalid type testing | Error handling validation |
| `test_decode_empty_tuple` | **✅** `tests/10.ABI.ts:375-395` - Round-trip empty tuple | **✅** `tests/unit_tests/test_abi.py:575-610` - Round-trip empty tuple | **TODO**: Empty tuple decode |
| `test_decode_simple_tuple` | **✅** `tests/10.ABI.ts:384-395` - Round-trip uint8,uint16 | **✅** `tests/unit_tests/test_abi.py:575-610` - Round-trip simple tuple | **TODO**: Simple tuple decode |
| `test_decode_mixed_tuple` | **✅** `tests/10.ABI.ts:375-395` - Round-trip mixed types | **✅** `tests/unit_tests/test_abi.py:575-610` - Round-trip mixed tuple | **TODO**: Mixed tuple decode |
| `test_decode_dynamic_tuple` | **✅** `tests/10.ABI.ts:365-395` - Round-trip dynamic arrays | **✅** `tests/unit_tests/test_abi.py:575-610` - Round-trip dynamic tuple | **TODO**: Dynamic tuple decode |
| `test_decode_nested_tuple` | **✅** `tests/10.ABI.ts:375-395` - Round-trip nested tuples | **✅** `tests/unit_tests/test_abi.py:575-610` - Round-trip nested tuple | **TODO**: Nested tuple decode |
| `test_decode_malformed_tuple_insufficient_bytes` | **🔄** `src/abi/abi_type.ts:700-750` - Length validation | **🔄** `algosdk/abi/tuple_type.py:decode()` - Length checks | **TODO**: Error handling for insufficient bytes |
| `test_decode_malformed_tuple_wrong_abi_type` | **✅** `src/abi/abi_type.ts:600-650` - Type validation errors | **✅** `tests/unit_tests/test_abi.py:160-180` - Invalid type testing | **TODO**: Error handling for wrong type |
| `test_decode_malformed_tuple_extra_bytes` | **🔄** `src/abi/abi_type.ts:700-750` - Length validation | **🔄** `algosdk/abi/tuple_type.py:decode()` - Length checks | **TODO**: Error handling for extra bytes |

---

## Uint Type Tests (14 tests)

| Test Name | TypeScript SDK Reference | Python SDK Reference | Notes |
|-----------|-------------------------|---------------------|-------|
| `test_uint_size_validation` | **✅** `src/abi/abi_type.ts:70-90` - Size validation | **✅** `tests/unit_tests/test_abi.py:25-30` - Size validation | Direct size validation pattern |
| `test_uint_boundary_values` | **✅** `src/abi/abi_type.ts:550-580` - Boundary testing | **✅** `tests/unit_tests/test_abi.py:385-395` - Boundary testing | Direct boundary testing pattern |
| `test_uint16_boundary_values` | **✅** `src/abi/abi_type.ts:550-580` - Boundary testing | **✅** `tests/unit_tests/test_abi.py:385-395` - Boundary testing | Direct boundary testing pattern |
| `test_uint32_boundary_values` | **✅** `src/abi/abi_type.ts:550-580` - Boundary testing | **✅** `tests/unit_tests/test_abi.py:385-395` - Boundary testing | Direct boundary testing pattern |
| `test_uint64_boundary_values` | **✅** `src/abi/abi_type.ts:550-580` - Boundary testing | **✅** `tests/unit_tests/test_abi.py:385-395` - Boundary testing | Direct boundary testing pattern |
| `test_uint256_large_values` | **✅** `src/abi/abi_type.ts:550-580` - Large value testing | **✅** `tests/unit_tests/test_abi.py:385-395` - Large value testing | Direct large value testing pattern |
| `test_uint_wrong_type` | **✅** `src/abi/abi_type.ts:600-650` - Type validation errors | **✅** `tests/unit_tests/test_abi.py:160-180` - Invalid type testing | Error handling validation |
| `test_uint_decode_wrong_length` | **🔄** `src/abi/abi_type.ts:700-750` - Length validation | **🔄** `algosdk/abi/uint_type.py:decode()` - Length checks | Follows SDK length validation patterns |
| `test_uint_decode_wrong_abi_type` | **✅** `src/abi/abi_type.ts:600-650` - Type validation errors | **✅** `tests/unit_tests/test_abi.py:160-180` - Invalid type testing | Error handling validation |
| `test_uint_encoding_deterministic` | **✅** `src/abi/abi_type.ts:600-650` - Deterministic encoding | **✅** `tests/unit_tests/test_abi.py:385-395` - Encoding consistency | Direct deterministic encoding pattern |
| `test_uint_odd_sizes` | **🔄** `src/abi/abi_type.ts:70-90` - Size validation | **✅** `tests/unit_tests/test_abi.py:25-30` - `range(8, 513, 8)` | Direct reference to Python SDK comprehensive size testing |
| `test_uint_max_size` | **✅** `src/abi/abi_type.ts:70-90` - Max size validation | **✅** `tests/unit_tests/test_abi.py:25-30` - Max size validation | Direct max size validation pattern |
| `test_uint_leading_zeros` | **🦀** No direct equivalent | **🦀** No direct equivalent | **Justification**: Rust-specific test ensuring leading zeros are properly handled in big-endian encoding |
| `test_uint_power_of_two_boundaries` | **🔄** `src/abi/abi_type.ts:550-580` - Boundary testing | **🔄** `tests/unit_tests/test_abi.py:385-395` - Boundary testing | Follows SDK boundary testing patterns for power-of-2 values |


As for next steps after merging we should also commit to renaming files prefixed with abi_ as well as removing redundant abi prefixes in ABIType enum