### PR TITLE
chore: aligning all crates to use 2024 edition

### DIFF
--- a/crates/algokit_abi/Cargo.toml
+++ b/crates/algokit_abi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "algokit_abi"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 thiserror = { workspace = true }

--- a/crates/algokit_abi/src/abi_type.rs
+++ b/crates/algokit_abi/src/abi_type.rs
@@ -1,10 +1,10 @@
 use crate::{
+    ABIError, ABIValue,
     constants::{
         ALGORAND_PUBLIC_KEY_BYTE_LENGTH, BITS_PER_BYTE, MAX_BIT_SIZE, MAX_PRECISION,
         STATIC_ARRAY_REGEX, UFIXED_REGEX,
     },
     types::collections::tuple::find_bool_sequence_end,
-    ABIError, ABIValue,
 };
 use std::{
     fmt::{Display, Formatter, Result as FmtResult},

--- a/crates/algokit_abi/src/types/collections/array_dynamic.rs
+++ b/crates/algokit_abi/src/types/collections/array_dynamic.rs
@@ -1,7 +1,7 @@
 use crate::{
+    ABIError, ABIType, ABIValue,
     constants::LENGTH_ENCODE_BYTE_SIZE,
     types::collections::tuple::{decode_abi_types, encode_abi_types},
-    ABIError, ABIType, ABIValue,
 };
 
 impl ABIType {
@@ -20,7 +20,7 @@ impl ABIType {
             _ => {
                 return Err(ABIError::EncodingError(
                     "ABI type mismatch, expected dynamic array".to_string(),
-                ))
+                ));
             }
         };
 
@@ -50,7 +50,7 @@ impl ABIType {
             _ => {
                 return Err(ABIError::EncodingError(
                     "ABI type mismatch, expected dynamic array".to_string(),
-                ))
+                ));
             }
         };
 

--- a/crates/algokit_abi/src/types/collections/array_static.rs
+++ b/crates/algokit_abi/src/types/collections/array_static.rs
@@ -1,6 +1,6 @@
 use crate::{
-    types::collections::tuple::{decode_abi_types, encode_abi_types},
     ABIError, ABIType, ABIValue,
+    types::collections::tuple::{decode_abi_types, encode_abi_types},
 };
 
 impl ABIType {
@@ -10,7 +10,7 @@ impl ABIType {
             _ => {
                 return Err(ABIError::EncodingError(
                     "ABI type mismatch, expected static array".to_string(),
-                ))
+                ));
             }
         };
 
@@ -32,7 +32,7 @@ impl ABIType {
             _ => {
                 return Err(ABIError::EncodingError(
                     "ABI type mismatch, expected static array".to_string(),
-                ))
+                ));
             }
         };
 

--- a/crates/algokit_abi/src/types/collections/tuple.rs
+++ b/crates/algokit_abi/src/types/collections/tuple.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use crate::{
-    constants::{BOOL_FALSE_BYTE, BOOL_TRUE_BYTE, LENGTH_ENCODE_BYTE_SIZE},
     ABIError, ABIType, ABIValue,
+    constants::{BOOL_FALSE_BYTE, BOOL_TRUE_BYTE, LENGTH_ENCODE_BYTE_SIZE},
 };
 
 struct Segment {
@@ -17,7 +17,7 @@ impl ABIType {
             _ => {
                 return Err(ABIError::EncodingError(
                     "ABI type mismatch, expected tuple".to_string(),
-                ))
+                ));
             }
         };
 
@@ -39,7 +39,7 @@ impl ABIType {
             _ => {
                 return Err(ABIError::DecodingError(
                     "ABI type mismatch, expected tuple".to_string(),
-                ))
+                ));
             }
         };
 
@@ -303,7 +303,7 @@ where
 mod tests {
     use num_bigint::BigUint;
 
-    use crate::{abi_type::BitSize, ABIType, ABIValue};
+    use crate::{ABIType, ABIValue, abi_type::BitSize};
 
     #[test]
     fn test_wrong_value_length() {
@@ -331,7 +331,10 @@ mod tests {
         let result = tuple_type.decode(&bytes);
 
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().to_string(), "ABI decoding failed: Index out of bounds: trying to access bytes[0..4] but slice has length 3");
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "ABI decoding failed: Index out of bounds: trying to access bytes[0..4] but slice has length 3"
+        );
     }
 
     #[test]
@@ -342,9 +345,11 @@ mod tests {
         let result = tuple_type.decode(&bytes);
 
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Input bytes not fully consumed"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Input bytes not fully consumed")
+        );
     }
 }

--- a/crates/algokit_abi/src/types/primitives/address.rs
+++ b/crates/algokit_abi/src/types/primitives/address.rs
@@ -1,11 +1,11 @@
 use sha2::{Digest, Sha512_256};
 
 use crate::{
+    ABIError, ABIType, ABIValue,
     constants::{
         ALGORAND_ADDRESS_LENGTH, ALGORAND_CHECKSUM_BYTE_LENGTH, ALGORAND_PUBLIC_KEY_BYTE_LENGTH,
         HASH_BYTES_LENGTH,
     },
-    ABIError, ABIType, ABIValue,
 };
 
 impl ABIType {

--- a/crates/algokit_abi/src/types/primitives/bool.rs
+++ b/crates/algokit_abi/src/types/primitives/bool.rs
@@ -1,6 +1,6 @@
 use crate::{
-    constants::{BOOL_FALSE_BYTE, BOOL_TRUE_BYTE},
     ABIError, ABIType, ABIValue,
+    constants::{BOOL_FALSE_BYTE, BOOL_TRUE_BYTE},
 };
 
 impl ABIType {

--- a/crates/algokit_abi/src/types/primitives/string.rs
+++ b/crates/algokit_abi/src/types/primitives/string.rs
@@ -1,4 +1,4 @@
-use crate::{constants::LENGTH_ENCODE_BYTE_SIZE, ABIError, ABIType, ABIValue};
+use crate::{ABIError, ABIType, ABIValue, constants::LENGTH_ENCODE_BYTE_SIZE};
 
 impl ABIType {
     pub(crate) fn encode_string(&self, value: &ABIValue) -> Result<Vec<u8>, ABIError> {

--- a/crates/algokit_abi/src/types/primitives/ufixed.rs
+++ b/crates/algokit_abi/src/types/primitives/ufixed.rs
@@ -1,6 +1,6 @@
 use num_bigint::BigUint;
 
-use crate::{utils, ABIError, ABIType, ABIValue};
+use crate::{ABIError, ABIType, ABIValue, utils};
 
 impl ABIType {
     pub(crate) fn encode_ufixed(&self, value: &ABIValue) -> Result<Vec<u8>, ABIError> {

--- a/crates/algokit_abi/src/types/primitives/uint.rs
+++ b/crates/algokit_abi/src/types/primitives/uint.rs
@@ -1,6 +1,6 @@
 use num_bigint::BigUint;
 
-use crate::{utils, ABIError, ABIType, ABIValue};
+use crate::{ABIError, ABIType, ABIValue, utils};
 
 impl ABIType {
     pub(crate) fn encode_uint(&self, value: &ABIValue) -> Result<Vec<u8>, ABIError> {

--- a/crates/algokit_transact/Cargo.toml
+++ b/crates/algokit_transact/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "algokit_transact"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [features]
 test_utils = ["dep:ed25519-dalek", "dep:convert_case"]

--- a/crates/algokit_transact/src/address.rs
+++ b/crates/algokit_transact/src/address.rs
@@ -11,7 +11,7 @@ use crate::{
     ALGORAND_ADDRESS_LENGTH, ALGORAND_CHECKSUM_BYTE_LENGTH, ALGORAND_PUBLIC_KEY_BYTE_LENGTH,
 };
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, Bytes};
+use serde_with::{Bytes, serde_as};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::str::FromStr;
 

--- a/crates/algokit_transact/src/keypair_account.rs
+++ b/crates/algokit_transact/src/keypair_account.rs
@@ -8,7 +8,7 @@ use crate::address::Address;
 use crate::constants::Byte32;
 use crate::error::AlgoKitTransactError;
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, Bytes};
+use serde_with::{Bytes, serde_as};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::str::FromStr;
 

--- a/crates/algokit_transact/src/multisig.rs
+++ b/crates/algokit_transact/src/multisig.rs
@@ -12,11 +12,11 @@
 use crate::address::Address;
 use crate::utils::hash;
 use crate::{
-    AlgoKitTransactError, ALGORAND_PUBLIC_KEY_BYTE_LENGTH, ALGORAND_SIGNATURE_BYTE_LENGTH,
+    ALGORAND_PUBLIC_KEY_BYTE_LENGTH, ALGORAND_SIGNATURE_BYTE_LENGTH, AlgoKitTransactError,
     MULTISIG_DOMAIN_SEPARATOR,
 };
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, Bytes};
+use serde_with::{Bytes, serde_as};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 /// Represents an Algorand multisignature signature.

--- a/crates/algokit_transact/src/test_utils/application_call.rs
+++ b/crates/algokit_transact/src/test_utils/application_call.rs
@@ -1,8 +1,8 @@
 use crate::{
-    test_utils::{AccountMother, TransactionHeaderMother},
     ApplicationCallTransactionBuilder, OnApplicationComplete, StateSchema,
+    test_utils::{AccountMother, TransactionHeaderMother},
 };
-use base64::{prelude::BASE64_STANDARD, Engine};
+use base64::{Engine, prelude::BASE64_STANDARD};
 
 pub struct ApplicationCallTransactionMother {}
 

--- a/crates/algokit_transact/src/test_utils/asset_config.rs
+++ b/crates/algokit_transact/src/test_utils/asset_config.rs
@@ -1,5 +1,5 @@
 use crate::{AssetConfigTransactionBuilder, Byte32, KeyPairAccount, TransactionHeaderBuilder};
-use base64::{prelude::BASE64_STANDARD, Engine};
+use base64::{Engine, prelude::BASE64_STANDARD};
 
 pub struct AssetConfigTransactionMother {}
 

--- a/crates/algokit_transact/src/test_utils/asset_freeze.rs
+++ b/crates/algokit_transact/src/test_utils/asset_freeze.rs
@@ -1,5 +1,5 @@
 use crate::{Address, AssetFreezeTransactionBuilder, Byte32, TransactionHeaderBuilder};
-use base64::{prelude::BASE64_STANDARD, Engine};
+use base64::{Engine, prelude::BASE64_STANDARD};
 
 pub struct AssetFreezeTransactionMother {}
 

--- a/crates/algokit_transact/src/test_utils/key_registration.rs
+++ b/crates/algokit_transact/src/test_utils/key_registration.rs
@@ -1,5 +1,5 @@
-use crate::{test_utils::TransactionHeaderMother, KeyRegistrationTransactionBuilder};
-use base64::{prelude::BASE64_STANDARD, Engine};
+use crate::{KeyRegistrationTransactionBuilder, test_utils::TransactionHeaderMother};
+use base64::{Engine, prelude::BASE64_STANDARD};
 
 pub struct KeyRegistrationTransactionMother {}
 

--- a/crates/algokit_transact/src/test_utils/mod.rs
+++ b/crates/algokit_transact/src/test_utils/mod.rs
@@ -4,12 +4,12 @@ mod asset_freeze;
 mod key_registration;
 
 use crate::{
+    ALGORAND_PUBLIC_KEY_BYTE_LENGTH, Address, AlgorandMsgpack, Byte32, HASH_BYTES_LENGTH,
+    KeyPairAccount, MultisigSignature, MultisigSubsignature, SignedTransaction, Transaction,
+    TransactionHeaderBuilder, TransactionId,
     transactions::{AssetTransferTransactionBuilder, PaymentTransactionBuilder},
-    Address, AlgorandMsgpack, Byte32, KeyPairAccount, MultisigSignature, MultisigSubsignature,
-    SignedTransaction, Transaction, TransactionHeaderBuilder, TransactionId,
-    ALGORAND_PUBLIC_KEY_BYTE_LENGTH, HASH_BYTES_LENGTH,
 };
-use base64::{prelude::BASE64_STANDARD, Engine};
+use base64::{Engine, prelude::BASE64_STANDARD};
 use convert_case::{Case, Casing};
 use ed25519_dalek::{Signer, SigningKey};
 use serde::Serialize;

--- a/crates/algokit_transact/src/tests.rs
+++ b/crates/algokit_transact/src/tests.rs
@@ -1,4 +1,6 @@
 use crate::{
+    AlgorandMsgpack, EstimateTransactionSize, KeyPairAccount, MultisigSignature, SignedTransaction,
+    Transaction, TransactionId, Transactions,
     constants::{
         ALGORAND_SIGNATURE_BYTE_LENGTH, ALGORAND_SIGNATURE_ENCODING_INCR, MAX_TX_GROUP_SIZE,
     },
@@ -6,10 +8,8 @@ use crate::{
         AccountMother, TransactionGroupMother, TransactionHeaderMother, TransactionMother,
     },
     transactions::FeeParams,
-    AlgorandMsgpack, EstimateTransactionSize, KeyPairAccount, MultisigSignature, SignedTransaction,
-    Transaction, TransactionId, Transactions,
 };
-use base64::{prelude::BASE64_STANDARD, Engine};
+use base64::{Engine, prelude::BASE64_STANDARD};
 use pretty_assertions::assert_eq;
 
 pub fn check_transaction_encoding(tx: &Transaction, expected_encoded_len: usize) {
@@ -358,9 +358,11 @@ fn test_transaction_group_too_big() {
     let result = txs.assign_group();
 
     let error = result.unwrap_err();
-    assert!(error
-        .to_string()
-        .starts_with("Transaction group size exceeds the max limit"));
+    assert!(
+        error
+            .to_string()
+            .starts_with("Transaction group size exceeds the max limit")
+    );
 }
 
 #[test]
@@ -370,9 +372,11 @@ fn test_transaction_group_too_small() {
     let result = txs.assign_group();
 
     let error = result.unwrap_err();
-    assert!(error
-        .to_string()
-        .starts_with("Transaction group size cannot be 0"));
+    assert!(
+        error
+            .to_string()
+            .starts_with("Transaction group size cannot be 0")
+    );
 }
 
 #[test]
@@ -397,9 +401,11 @@ fn test_transaction_group_already_set() {
     let result = vec![tx].assign_group();
 
     let error = result.unwrap_err();
-    assert!(error
-        .to_string()
-        .starts_with("Transactions must not already be grouped"));
+    assert!(
+        error
+            .to_string()
+            .starts_with("Transactions must not already be grouped")
+    );
 }
 
 #[test]

--- a/crates/algokit_transact/src/traits.rs
+++ b/crates/algokit_transact/src/traits.rs
@@ -3,9 +3,9 @@
 //! This module provides traits for standardized MessagePack encoding/decoding of
 //! Algorand data structures and for calculating transaction identifiers.
 
+use crate::Transaction;
 use crate::error::AlgoKitTransactError;
 use crate::utils::sort_msgpack_value;
-use crate::Transaction;
 use crate::{constants::HASH_BYTES_LENGTH, utils::hash};
 use serde::{Deserialize, Serialize};
 

--- a/crates/algokit_transact/src/transactions/application_call.rs
+++ b/crates/algokit_transact/src/transactions/application_call.rs
@@ -450,7 +450,7 @@ impl ApplicationCallTransactionFields {
         }
 
         // Validate combined program size
-        if let (Some(ref approval_program), Some(ref clear_state_program)) =
+        if let (Some(approval_program), Some(clear_state_program)) =
             (&self.approval_program, &self.clear_state_program)
         {
             let total_size = approval_program.len() + clear_state_program.len();

--- a/crates/algokit_transact/src/transactions/application_call.rs
+++ b/crates/algokit_transact/src/transactions/application_call.rs
@@ -10,7 +10,7 @@ use crate::{Address, Transaction};
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use serde_with::{serde_as, skip_serializing_none, Bytes};
+use serde_with::{Bytes, serde_as, skip_serializing_none};
 
 // Application program size constraints (based on Algorand protocol)
 const MAX_EXTRA_PROGRAM_PAGES: u64 = 3;
@@ -687,11 +687,11 @@ impl Validate for ApplicationCallTransactionFields {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::AlgorandMsgpack;
     use crate::test_utils::{
         AccountMother, ApplicationCallTransactionMother, TransactionHeaderMother,
     };
     use crate::tests::{check_transaction_encoding, check_transaction_id};
-    use crate::AlgorandMsgpack;
 
     #[test]
     fn test_application_create_transaction_encoding() {
@@ -972,21 +972,31 @@ mod tests {
 
         println!("Validation errors ({}): {:?}", errors.len(), errors);
 
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_APPROVAL_PROGRAM) && e.contains("required")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_CLEAR_STATE_PROGRAM) && e.contains("required")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_EXTRA_PROGRAM_PAGES) && e.contains("exceed")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_GLOBAL_STATE_SCHEMA) && e.contains("exceed")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_LOCAL_STATE_SCHEMA) && e.contains("exceed")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_APPROVAL_PROGRAM) && e.contains("required"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_CLEAR_STATE_PROGRAM) && e.contains("required"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_EXTRA_PROGRAM_PAGES) && e.contains("exceed"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_GLOBAL_STATE_SCHEMA) && e.contains("exceed"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_LOCAL_STATE_SCHEMA) && e.contains("exceed"))
+        );
         assert!(
             errors.len() == 5,
             "Expected 5 validation errors, got {}",
@@ -1012,16 +1022,22 @@ mod tests {
 
         println!("Validation errors ({}): {:?}", errors.len(), errors);
 
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_APPROVAL_PROGRAM) && e.contains("exceed")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_CLEAR_STATE_PROGRAM) && e.contains("exceed")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains("Combined approval and clear state programs")
-                && e.contains("exceed")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_APPROVAL_PROGRAM) && e.contains("exceed"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_CLEAR_STATE_PROGRAM) && e.contains("exceed"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("Combined approval and clear state programs")
+                    && e.contains("exceed"))
+        );
     }
 
     #[test]
@@ -1057,24 +1073,36 @@ mod tests {
 
         println!("Validation errors ({}): {:?}", errors.len(), errors);
 
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_APP_ID) && e.contains("0")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_APPROVAL_PROGRAM) && e.contains("required")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_CLEAR_STATE_PROGRAM) && e.contains("required")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_GLOBAL_STATE_SCHEMA) && e.contains("immutable")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_LOCAL_STATE_SCHEMA) && e.contains("immutable")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_EXTRA_PROGRAM_PAGES) && e.contains("immutable")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_APP_ID) && e.contains("0"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_APPROVAL_PROGRAM) && e.contains("required"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_CLEAR_STATE_PROGRAM) && e.contains("required"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_GLOBAL_STATE_SCHEMA) && e.contains("immutable"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_LOCAL_STATE_SCHEMA) && e.contains("immutable"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_EXTRA_PROGRAM_PAGES) && e.contains("immutable"))
+        );
         assert!(
             errors.len() == 6,
             "Expected 6 validation errors, got {}",
@@ -1113,19 +1141,27 @@ mod tests {
 
         println!("Validation errors ({}): {:?}", errors.len(), errors);
 
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_APP_ID) && e.contains("0")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_APP_ID) && e.contains("0"))
+        );
 
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_GLOBAL_STATE_SCHEMA) && e.contains("immutable")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_LOCAL_STATE_SCHEMA) && e.contains("immutable")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_EXTRA_PROGRAM_PAGES) && e.contains("immutable")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_GLOBAL_STATE_SCHEMA) && e.contains("immutable"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_LOCAL_STATE_SCHEMA) && e.contains("immutable"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_EXTRA_PROGRAM_PAGES) && e.contains("immutable"))
+        );
 
         assert!(
             errors.len() == 4,
@@ -1165,18 +1201,26 @@ mod tests {
 
         println!("Validation errors ({}): {:?}", errors.len(), errors);
 
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_APP_ID) && e.contains("0")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_GLOBAL_STATE_SCHEMA) && e.contains("immutable")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_LOCAL_STATE_SCHEMA) && e.contains("immutable")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_EXTRA_PROGRAM_PAGES) && e.contains("immutable")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_APP_ID) && e.contains("0"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_GLOBAL_STATE_SCHEMA) && e.contains("immutable"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_LOCAL_STATE_SCHEMA) && e.contains("immutable"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_EXTRA_PROGRAM_PAGES) && e.contains("immutable"))
+        );
 
         assert!(
             errors.len() == 4,
@@ -1200,12 +1244,16 @@ mod tests {
 
         println!("Validation errors ({}): {:?}", errors.len(), errors);
 
-        assert!(errors
-            .iter()
-            .any(|e| e.contains(FIELD_ARGS) && e.contains("exceed")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains("Args total size") && e.contains("exceed")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains(FIELD_ARGS) && e.contains("exceed"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("Args total size") && e.contains("exceed"))
+        );
 
         assert!(
             errors.len() == 2,
@@ -1251,24 +1299,36 @@ mod tests {
 
         println!("Validation errors ({}): {:?}", errors.len(), errors);
 
-        assert!(errors
-            .iter()
-            .any(|e| e.contains("Account references") && e.contains("exceed")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains("Application references") && e.contains("exceed")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains("Asset references") && e.contains("exceed")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains("Box references") && e.contains("exceed")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains("Box reference for app ID 88888 must be in app references")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains("Total references") && e.contains("exceed")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("Account references") && e.contains("exceed"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("Application references") && e.contains("exceed"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("Asset references") && e.contains("exceed"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("Box references") && e.contains("exceed"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("Box reference for app ID 88888 must be in app references"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("Total references") && e.contains("exceed"))
+        );
 
         assert!(
             errors.len() == 6,

--- a/crates/algokit_transact/src/transactions/asset_config.rs
+++ b/crates/algokit_transact/src/transactions/asset_config.rs
@@ -9,7 +9,7 @@ use crate::utils::{is_false_opt, is_zero, is_zero_addr_opt, is_zero_opt};
 use crate::{Address, Transaction};
 use derive_builder::Builder;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_with::{serde_as, skip_serializing_none, Bytes};
+use serde_with::{Bytes, serde_as, skip_serializing_none};
 
 // Only used for serialise/deserialise
 #[serde_as]

--- a/crates/algokit_transact/src/transactions/asset_freeze.rs
+++ b/crates/algokit_transact/src/transactions/asset_freeze.rs
@@ -3,10 +3,10 @@
 //! This module provides functionality for creating and managing asset freeze transactions,
 //! which are used to freeze or unfreeze asset holdings for specific accounts.
 
+use crate::Transaction;
 use crate::address::Address;
 use crate::transactions::common::TransactionHeader;
 use crate::utils::{is_zero, is_zero_addr};
-use crate::Transaction;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, skip_serializing_none};

--- a/crates/algokit_transact/src/transactions/common.rs
+++ b/crates/algokit_transact/src/transactions/common.rs
@@ -3,15 +3,15 @@
 //! This module provides the fundamental transaction types and headers used
 //! across different transaction types.
 
+use crate::Address;
 use crate::constants::Byte32;
 use crate::utils::{
     is_empty_bytes32_opt, is_empty_string_opt, is_empty_vec_opt, is_zero, is_zero_addr,
     is_zero_addr_opt, is_zero_opt,
 };
-use crate::Address;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, skip_serializing_none, Bytes};
+use serde_with::{Bytes, serde_as, skip_serializing_none};
 
 /// Common header fields shared by all transaction types.
 ///

--- a/crates/algokit_transact/src/transactions/key_registration.rs
+++ b/crates/algokit_transact/src/transactions/key_registration.rs
@@ -3,13 +3,13 @@
 //! This module provides functionality for creating and managing key registration transactions,
 //! which are used to register accounts online or offline for participation in Algorand consensus.
 
+use crate::Transaction;
 use crate::traits::Validate;
 use crate::transactions::common::{TransactionHeader, TransactionValidationError};
 use crate::utils::{is_false_opt, is_zero_opt};
-use crate::Transaction;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, skip_serializing_none, Bytes};
+use serde_with::{Bytes, serde_as, skip_serializing_none};
 
 /// Represents a key registration transaction that registers an account online or offline
 /// for participation in Algorand consensus.
@@ -256,9 +256,11 @@ mod tests {
         let result = key_reg.validate();
         assert!(result.is_err());
         let errors: Vec<String> = result.unwrap_err();
-        assert!(errors
-            .iter()
-            .any(|e| e.contains("Vote first must be less than vote last")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("Vote first must be less than vote last"))
+        );
     }
 
     #[test]
@@ -272,9 +274,11 @@ mod tests {
         let result = key_reg.validate();
         assert!(result.is_err());
         let errors = result.unwrap_err();
-        assert!(errors
-            .iter()
-            .any(|e| e.contains("Vote first must be less than vote last")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("Vote first must be less than vote last"))
+        );
     }
 
     #[test]
@@ -288,9 +292,12 @@ mod tests {
         let result = key_reg.validate();
         assert!(result.is_err());
         let errors = result.unwrap_err();
-        assert!(errors
-            .iter()
-            .any(|e| e.contains("Online key registration cannot have non participation flag set")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e
+                    .contains("Online key registration cannot have non participation flag set"))
+        );
     }
 
     #[test]
@@ -305,17 +312,23 @@ mod tests {
         assert!(result.is_err());
         let errors = result.unwrap_err();
         // Since vote_key is set, it should be treated as online registration with missing required fields
-        assert!(errors
-            .iter()
-            .any(|e| e.contains("Selection key is required")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains("State proof key is required")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("Selection key is required"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("State proof key is required"))
+        );
         assert!(errors.iter().any(|e| e.contains("Vote first is required")));
         assert!(errors.iter().any(|e| e.contains("Vote last is required")));
-        assert!(errors
-            .iter()
-            .any(|e| e.contains("Vote key dilution is required")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("Vote key dilution is required"))
+        );
     }
 
     #[test]
@@ -378,6 +391,7 @@ mod tests {
     // Integration tests for encoding and transaction functionality
     mod integration_tests {
         use crate::{
+            AlgorandMsgpack, SignedTransaction, Transaction, Transactions,
             constants::ALGORAND_SIGNATURE_BYTE_LENGTH,
             test_utils::{
                 AccountMother, KeyRegistrationTransactionMother, TransactionHeaderMother,
@@ -385,7 +399,6 @@ mod tests {
             },
             traits::TransactionId,
             transactions::FeeParams,
-            AlgorandMsgpack, SignedTransaction, Transaction, Transactions,
         };
 
         #[test]

--- a/crates/algokit_transact/src/transactions/mod.rs
+++ b/crates/algokit_transact/src/transactions/mod.rs
@@ -12,14 +12,14 @@ mod common;
 mod key_registration;
 mod payment;
 
-use application_call::{application_call_deserializer, application_call_serializer};
 pub use application_call::{
     ApplicationCallTransactionBuilder, ApplicationCallTransactionFields, BoxReference,
     OnApplicationComplete, StateSchema,
 };
+use application_call::{application_call_deserializer, application_call_serializer};
 pub use asset_config::{
-    asset_config_deserializer, asset_config_serializer, AssetConfigTransactionBuilder,
-    AssetConfigTransactionFields,
+    AssetConfigTransactionBuilder, AssetConfigTransactionFields, asset_config_deserializer,
+    asset_config_serializer,
 };
 pub use asset_freeze::{AssetFreezeTransactionBuilder, AssetFreezeTransactionFields};
 pub use asset_transfer::{AssetTransferTransactionBuilder, AssetTransferTransactionFields};
@@ -36,7 +36,7 @@ use crate::traits::{AlgorandMsgpack, EstimateTransactionSize, TransactionId, Tra
 use crate::utils::{compute_group_id, is_zero_addr_opt};
 use crate::{Address, MultisigSignature};
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, Bytes};
+use serde_with::{Bytes, serde_as};
 use std::any::Any;
 
 /// Enumeration of all transaction types.

--- a/crates/algokit_transact/src/utils.rs
+++ b/crates/algokit_transact/src/utils.rs
@@ -1,9 +1,9 @@
 use crate::constants::{
-    Byte32, ALGORAND_CHECKSUM_BYTE_LENGTH, ALGORAND_PUBLIC_KEY_BYTE_LENGTH, HASH_BYTES_LENGTH,
+    ALGORAND_CHECKSUM_BYTE_LENGTH, ALGORAND_PUBLIC_KEY_BYTE_LENGTH, Byte32, HASH_BYTES_LENGTH,
 };
 use crate::{Address, AlgoKitTransactError, AlgorandMsgpack, Transaction, TransactionId};
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, skip_serializing_none, Bytes};
+use serde_with::{Bytes, serde_as, skip_serializing_none};
 use sha2::{Digest, Sha512_256};
 use std::collections::BTreeMap;
 

--- a/crates/algokit_transact_ffi/Cargo.toml
+++ b/crates/algokit_transact_ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "algokit_transact_ffi"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["lib", "cdylib", "staticlib"]

--- a/crates/algokit_transact_ffi/src/multisig.rs
+++ b/crates/algokit_transact_ffi/src/multisig.rs
@@ -171,10 +171,10 @@ pub fn merge_multisignatures(
 
 #[cfg(test)]
 mod tests {
-    use algokit_transact::test_utils::TransactionMother;
     use algokit_transact::AlgorandMsgpack;
-    use base64::prelude::BASE64_STANDARD;
+    use algokit_transact::test_utils::TransactionMother;
     use base64::Engine;
+    use base64::prelude::BASE64_STANDARD;
 
     #[test]
     fn test_multisig_transaction_matches_observed_transaction() {

--- a/crates/ffi_macros/Cargo.toml
+++ b/crates/ffi_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ffi_macros"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 proc-macro = true

--- a/crates/ffi_macros/src/lib.rs
+++ b/crates/ffi_macros/src/lib.rs
@@ -2,8 +2,8 @@
 
 use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
-use quote::{quote, ToTokens};
-use syn::{parse_macro_input, Field, Fields, ItemEnum, ItemFn, ItemStruct, Type, TypePath};
+use quote::{ToTokens, quote};
+use syn::{Field, Fields, ItemEnum, ItemFn, ItemStruct, Type, TypePath, parse_macro_input};
 
 #[proc_macro_attribute]
 pub fn ffi_func(_attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/crates/uniffi-bindgen/Cargo.toml
+++ b/crates/uniffi-bindgen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-bindgen"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 uniffi = { workspace = true, features = ["cli"] }

--- a/docs/Cargo.toml
+++ b/docs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "docs"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 mdbook = "0.4"


### PR DESCRIPTION
# Proposed changes
- Updated edition = "2024" in 6 Cargo.toml files
- Fixed pattern matching in application_call.rs for 2024 edition compatibility
- All crates now use consistent 2024 edition
- Applying cargo fmt with 2024 rules on updated crates

## Implications

Per the https://doc.rust-lang.org/edition-guide/editions/index.html: 
"crates in one edition must seamlessly interoperate with those compiled with other editions"

From my understanding of the above they don't affect library consumers and we are not publishing the crates at the moment either. 

So it will primarily affect our own dev experience and provide: 
- Enhanced Clippy linting and error messages
- Modern language features and idioms