### PR TITLE
dep: update uniffi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "thiserror 2.0.7",
- "tsify-next",
+ "tsify",
  "uniffi",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -123,7 +123,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "thiserror 2.0.7",
- "tsify-next",
+ "tsify",
  "uniffi",
  "wasm-bindgen",
  "wasm-pack",
@@ -4118,24 +4118,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tsify-next"
-version = "0.5.4"
+name = "tsify"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4a645dca4ee0800f5ab60ce166deba2db6a0315de795a2691e138a3d55d756"
+checksum = "b2ec91b85e6c6592ed28636cb1dd1fac377ecbbeb170ff1d79f97aac5e38926d"
 dependencies = [
  "gloo-utils",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
- "tsify-next-macros",
+ "tsify-macros",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "tsify-next-macros"
-version = "0.5.4"
+name = "tsify-macros"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5c06f8a51d759bb58129e30b2631739e7e1e4579fad1f30ac09a6c88e488a6"
+checksum = "9a324606929ad11628a19206d7853807481dcaecd6c08be70a235930b8241955"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 uniffi = { version = "0.29.4" }
 thiserror = { version = "2.0.7" }
 wasm-bindgen = { version = "0.2.99" }
-tsify-next = { version = "0.5.4", features = ["js"] }
+tsify = { version = "0.5.5", features = ["js"] }
 js-sys = { version = "0.3.77" }
 base32 = { version = "0.5.1" }
 sha2 = { version = "0.10.8" }

--- a/crates/algokit_http_client/Cargo.toml
+++ b/crates/algokit_http_client/Cargo.toml
@@ -9,7 +9,7 @@ ffi_uniffi = ["dep:uniffi"]
 ffi_wasm = [
   "dep:wasm-bindgen",
   "dep:js-sys",
-  "dep:tsify-next",
+  "dep:tsify",
   "dep:serde-wasm-bindgen",
 ]
 default_client = ["dep:reqwest"]
@@ -21,7 +21,7 @@ reqwest = { version = "0.12.19", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = { version = "0.6", optional = true }
 thiserror.workspace = true
-tsify-next = { workspace = true, optional = true }
+tsify = { workspace = true, optional = true }
 uniffi = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 wasm-bindgen-futures = "0.4.50"

--- a/crates/algokit_http_client/src/lib.rs
+++ b/crates/algokit_http_client/src/lib.rs
@@ -13,7 +13,7 @@ pub enum HttpError {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "ffi_uniffi", derive(uniffi::Enum))]
-#[cfg_attr(feature = "ffi_wasm", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "ffi_wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "ffi_wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[cfg_attr(feature = "ffi_wasm", derive(serde::Serialize, serde::Deserialize))]
 pub enum HttpMethod {
@@ -42,7 +42,7 @@ impl HttpMethod {
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "ffi_uniffi", derive(uniffi::Record))]
-#[cfg_attr(feature = "ffi_wasm", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "ffi_wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "ffi_wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[cfg_attr(feature = "ffi_wasm", derive(serde::Serialize, serde::Deserialize))]
 pub struct HttpResponse {
@@ -185,7 +185,7 @@ use wasm_bindgen::prelude::*;
 use js_sys::Uint8Array;
 
 #[cfg(feature = "ffi_wasm")]
-use tsify_next::Tsify;
+use tsify::Tsify;
 
 #[cfg(feature = "ffi_wasm")]
 #[async_trait(?Send)]

--- a/crates/algokit_transact_ffi/Cargo.toml
+++ b/crates/algokit_transact_ffi/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 
 [features]
 default = ["ffi_uniffi"]
-ffi_wasm = ["dep:wasm-bindgen", "dep:tsify-next", "dep:js-sys"]
+ffi_wasm = ["dep:wasm-bindgen", "dep:tsify", "dep:js-sys"]
 ffi_uniffi = ["dep:uniffi"]
 
 [dependencies]
@@ -22,7 +22,7 @@ serde_bytes = "0.11.15"
 serde_json = "1.0.133"
 base64 = "0.22.1"
 
-tsify-next = { workspace = true, optional = true }
+tsify = { workspace = true, optional = true }
 uniffi = { workspace = true, features = [
   "scaffolding-ffi-buffer-fns",
 ], optional = true }
@@ -46,6 +46,6 @@ serde = { version = "1.0.216", features = ["derive"] }
 serde_bytes = "0.11.15"
 serde_json = "1.0.133"
 base64 = "0.22.1"
-tsify-next = { workspace = true, optional = true }
+tsify = { workspace = true, optional = true }
 js-sys = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }

--- a/crates/algokit_transact_ffi/src/lib.rs
+++ b/crates/algokit_transact_ffi/src/lib.rs
@@ -80,7 +80,7 @@ uniffi::setup_scaffolding!();
 #[cfg(feature = "ffi_wasm")]
 use js_sys::Uint8Array;
 #[cfg(feature = "ffi_wasm")]
-use tsify_next::Tsify;
+use tsify::Tsify;
 #[cfg(feature = "ffi_wasm")]
 use wasm_bindgen::prelude::*;
 

--- a/crates/algokit_transact_ffi/src/transactions/keyreg.rs
+++ b/crates/algokit_transact_ffi/src/transactions/keyreg.rs
@@ -5,7 +5,7 @@
 use crate::*;
 
 #[cfg(feature = "ffi_wasm")]
-use tsify_next::Tsify;
+use tsify::Tsify;
 
 #[ffi_record]
 pub struct KeyRegistrationTransactionFields {


### PR DESCRIPTION
Only change for us is custom_type! macro. Needed for UBRN

Also it should be noted that this precludes us from using the Go binding generator since it's still on 0.28. There is a PR for 0.29 support here: https://github.com/NordSecurity/uniffi-bindgen-go/pull/77
