### PR TITLE
chore: added codeowners file for round robin assignment for code reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @algorandfoundation/ak-core


### PR DESCRIPTION
Created an `ak-core` team and configured round robin PR review assignment. Just need to add this file to get it going. 