### PR TITLE
fix: add missing npm ci step to oas cron

### DIFF
--- a/.github/workflows/api_openapi_sync.yml
+++ b/.github/workflows/api_openapi_sync.yml
@@ -21,6 +21,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-api-tools
 
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: api/package-lock.json
+
+      - name: Install api oas converter dependencies
+        working-directory: api
+        run: npm ci
+
       - name: Store initial state for ${{ matrix.spec }}
         run: git status --porcelain > /tmp/initial_${{ matrix.spec }}_status.txt
 


### PR DESCRIPTION
Adds the necessary dependencies for the api oas converter to the api_openapi_sync workflow.

Initially the error was caused by switch from bun to npm in ts client generator pr. 

Verified fix is working in workflow dispatch from this branch https://github.com/algorandfoundation/algokit-core/actions/runs/18093117252
