### PR TITLE
ci: zip swift project in cd

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,9 +1,9 @@
 name: CI/CD
 
 on:
-  # push: # A push indicates that a PR is merged and CD should be triggered
-  #   branches:
-  #     - main
+  push: # A push indicates that a PR is merged and CD should be triggered
+    branches:
+      - main
   pull_request: # For PRs, we run CI, which is the same as CD without the release step(s)
     branches:
       - main

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   check_rust:
     runs-on: ubuntu-latest

--- a/.github/workflows/swift_ci.yml
+++ b/.github/workflows/swift_ci.yml
@@ -64,3 +64,12 @@ jobs:
       - name: Test (Catalyst)
         run: cd packages/swift/${{ env.PACKAGE }} && xcodebuild -scheme ${{ env.PACKAGE }} test -destination "platform=macOS,variant=Mac Catalyst"
 
+      - name: Zip Swift package
+        run: cd packages/swift && zip -r ${{ env.PACKAGE }}.zip ${{ env.PACKAGE }} -x "${{ env.PACKAGE }}/.build/*"
+
+      - name: Upload Swift package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PACKAGE }}
+          path: packages/swift/${{ env.PACKAGE }}.zip
+

--- a/.github/workflows/swift_ci.yml
+++ b/.github/workflows/swift_ci.yml
@@ -65,9 +65,11 @@ jobs:
         run: cd packages/swift/${{ env.PACKAGE }} && xcodebuild -scheme ${{ env.PACKAGE }} test -destination "platform=macOS,variant=Mac Catalyst"
 
       - name: Zip Swift package
+        if: inputs.release
         run: cd packages/swift && zip -r ${{ env.PACKAGE }}.zip ${{ env.PACKAGE }} -x "${{ env.PACKAGE }}/.build/*"
 
       - name: Upload Swift package artifact
+        if: inputs.release
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PACKAGE }}


### PR DESCRIPTION
Zips up the entire SPM project into a zip file. This runs every push on main (every merged PR). Eventually we want to publish the SPM project to its own repo so it can be used directly with SPM (SPM doesn't work with monorepos). 

Ensure it worked via this run https://github.com/algorandecosystem/algokit-core/actions/runs/21492772476/job/61919453208

 https://github.com/algorandecosystem/algokit-core/actions/runs/21492772476/artifacts/5309424264
