### PR TITLE
chore: relax reqwest version

### DIFF
--- a/crates/algokit_http_client/Cargo.toml
+++ b/crates/algokit_http_client/Cargo.toml
@@ -10,7 +10,7 @@ default_client = ["dep:reqwest"]
 
 [dependencies]
 async-trait = "0.1.88"
-reqwest = { version = "0.12.19", optional = true }
+reqwest = { version = "0.12", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 snafu = { workspace = true }
 uniffi = { workspace = true, optional = true }


### PR DESCRIPTION
This relaxes the min reqwest version for the default HTTP client. This is needed to be compatible with the SP1 SDK
