### PR TITLE
feat(crypto): add hd wallet to crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ name = "algokit_crypto"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bip39",
  "cryptoxide",
  "ed25519-bip32",
  "getrandom 0.4.1",
@@ -251,6 +252,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "askama"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +390,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bip39"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
+dependencies = [
+ "bitcoin_hashes",
+ "serde",
+ "unicode-normalization",
+ "zeroize",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+dependencies = [
+ "hex-conservative",
 ]
 
 [[package]]
@@ -1374,6 +1402,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "home"
@@ -3491,6 +3528,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3765,6 +3817,15 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,9 +73,11 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "cryptoxide",
+ "ed25519-bip32",
  "getrandom 0.4.1",
  "sha2",
  "signature",
+ "snafu",
  "tokio",
  "zeroize",
 ]
@@ -935,6 +937,14 @@ checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
  "signature",
+]
+
+[[package]]
+name = "ed25519-bip32"
+version = "0.4.1"
+source = "git+https://github.com/algorandfoundation/xHD-Wallet-API-rs.git?rev=3cafd074e840971a2de791593918bb1c0707cd04#3cafd074e840971a2de791593918bb1c0707cd04"
+dependencies = [
+ "cryptoxide",
 ]
 
 [[package]]

--- a/crates/algokit_crypto/Cargo.toml
+++ b/crates/algokit_crypto/Cargo.toml
@@ -18,5 +18,13 @@ getrandom = "0.4.1"
 async-trait = "0.1.89"
 sha2.workspace = true
 
+# BIP32-Ed25519 (XHD wallet) derivation and raw signing.
+# Pinned by commit so the build is deterministic. The fork's package name is
+# kept as `ed25519-bip32` from the upstream typed-io crate it forks.
+ed25519-bip32 = { git = "https://github.com/algorandfoundation/xHD-Wallet-API-rs.git", rev = "3cafd074e840971a2de791593918bb1c0707cd04" }
+
+# Error derive helper, matching the workspace-wide convention
+snafu = { workspace = true }
+
 [dev-dependencies]
 tokio = { version = "1.49.0", features = ["macros", "rt"] }

--- a/crates/algokit_crypto/Cargo.toml
+++ b/crates/algokit_crypto/Cargo.toml
@@ -23,6 +23,10 @@ sha2.workspace = true
 # kept as `ed25519-bip32` from the upstream typed-io crate it forks.
 ed25519-bip32 = { git = "https://github.com/algorandfoundation/xHD-Wallet-API-rs.git", rev = "3cafd074e840971a2de791593918bb1c0707cd04" }
 
+# BIP39 mnemonic ↔ 64-byte seed conversion. `zeroize` feature wires the
+# crate's internal `Mnemonic`/`Seed` buffers to `ZeroizeOnDrop`.
+bip39 = { version = "2.2", default-features = false, features = ["std", "zeroize"] }
+
 snafu = { workspace = true }
 
 [dev-dependencies]

--- a/crates/algokit_crypto/Cargo.toml
+++ b/crates/algokit_crypto/Cargo.toml
@@ -23,7 +23,6 @@ sha2.workspace = true
 # kept as `ed25519-bip32` from the upstream typed-io crate it forks.
 ed25519-bip32 = { git = "https://github.com/algorandfoundation/xHD-Wallet-API-rs.git", rev = "3cafd074e840971a2de791593918bb1c0707cd04" }
 
-# Error derive helper, matching the workspace-wide convention
 snafu = { workspace = true }
 
 [dev-dependencies]

--- a/crates/algokit_crypto/src/lib.rs
+++ b/crates/algokit_crypto/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod algo25;
 pub mod ed25519;
+pub mod xhd;
 pub use signature::{Keypair, Signer};

--- a/crates/algokit_crypto/src/xhd.rs
+++ b/crates/algokit_crypto/src/xhd.rs
@@ -11,11 +11,13 @@
 //! storage, zeroization, and BIP44 path bookkeeping are the responsibility of
 //! the caller.
 
+use bip39::Mnemonic;
 use ed25519_bip32::{
     DerivationScheme, Signature, XPrv,
     api::{KeyContext as UpstreamKeyContext, key_gen as upstream_key_gen},
 };
 use snafu::Snafu;
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 pub const HD_SEED_SIZE: usize = 64;
 pub const XPRV_SIZE: usize = 96;
@@ -33,6 +35,9 @@ pub enum XhdError {
 
     #[snafu(display("Extended private key bytes failed verification"))]
     InvalidXprv,
+
+    #[snafu(display("Invalid BIP39 mnemonic: {reason}"))]
+    InvalidMnemonic { reason: String },
 }
 
 /// Selects the BIP44 `coin_type` slot used when deriving a key.
@@ -59,7 +64,9 @@ impl From<KeyContext> for UpstreamKeyContext {
 ///
 /// Contains the 96-byte extended private key (32-byte scalar, 32-byte prefix,
 /// and 32-byte chain code) and the corresponding 32-byte ed25519 public key.
-#[derive(Debug, Clone)]
+/// The struct is `ZeroizeOnDrop`: the extended private key bytes are
+/// overwritten with zeros when the value is dropped.
+#[derive(Debug, Clone, Zeroize, ZeroizeOnDrop)]
 pub struct DerivedAccount {
     /// Extended private key: 32-byte scalar, 32-byte prefix, 32-byte chain code.
     pub xprv: [u8; XPRV_SIZE],
@@ -82,14 +89,45 @@ pub fn root_key_from_seed(seed: &[u8]) -> Result<[u8; XPRV_SIZE], XhdError> {
         });
     }
 
-    let seed_array: [u8; HD_SEED_SIZE] =
-        seed.try_into().map_err(|_| XhdError::InvalidSeedLength {
+    let seed_array: Zeroizing<[u8; HD_SEED_SIZE]> =
+        Zeroizing::new(seed.try_into().map_err(|_| XhdError::InvalidSeedLength {
             expected: HD_SEED_SIZE,
             found: seed.len(),
-        })?;
+        })?);
 
     let xprv = XPrv::from_seed(&seed_array);
     Ok(xprv.into())
+}
+
+/// Derives a 64-byte BIP39 seed from a 12/15/18/21/24-word mnemonic.
+///
+/// The BIP39 passphrase is hardcoded to the empty string; this module does
+/// not expose passphrase-based derivation. See the BIP39 specification at
+/// <https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki>.
+///
+/// # Errors
+///
+/// Returns [`XhdError::InvalidMnemonic`] if `mnemonic` is not a valid BIP39
+/// phrase (unknown word, wrong length, bad checksum).
+pub fn seed_from_mnemonic(mnemonic: &str) -> Result<[u8; HD_SEED_SIZE], XhdError> {
+    let parsed = Mnemonic::parse(mnemonic).map_err(|e| XhdError::InvalidMnemonic {
+        reason: e.to_string(),
+    })?;
+    Ok(parsed.to_seed(""))
+}
+
+/// Derives a 96-byte root extended private key directly from a BIP39 mnemonic.
+///
+/// Convenience wrapper that composes [`seed_from_mnemonic`] and
+/// [`root_key_from_seed`]. The intermediate 64-byte seed is held in a
+/// `Zeroizing` buffer and cleared when this function returns.
+///
+/// # Errors
+///
+/// Propagates errors from [`seed_from_mnemonic`].
+pub fn root_key_from_mnemonic(mnemonic: &str) -> Result<[u8; XPRV_SIZE], XhdError> {
+    let seed = Zeroizing::new(seed_from_mnemonic(mnemonic)?);
+    root_key_from_seed(seed.as_slice())
 }
 
 /// Derives an extended private key at the BIP44 path
@@ -121,6 +159,7 @@ pub fn derive(
     .map_err(|_| XhdError::InvalidXprv)?;
 
     let public_key = derived.public().public_key();
+    // `derived: XPrv` zeroes its internal buffer on drop upstream; no Zeroizing<> wrap needed here.
     let xprv: [u8; XPRV_SIZE] = derived.into();
 
     Ok(DerivedAccount { xprv, public_key })
@@ -138,6 +177,7 @@ pub fn derive(
 /// [`XPRV_SIZE`] bytes, or [`XhdError::InvalidXprv`] if the bytes do not form
 /// a valid extended private key.
 pub fn raw_sign(extended_key: &[u8], msg: &[u8]) -> Result<[u8; SIGNATURE_SIZE], XhdError> {
+    // The parsed `XPrv` zeroes its internal buffer on drop upstream; no Zeroizing<> wrap needed here.
     let xprv = parse_xprv(extended_key)?;
     let signature: Signature<Vec<u8>> = xprv.sign(msg);
 
@@ -315,5 +355,56 @@ mod tests {
                 found: 64
             }
         );
+    }
+
+    // BIP39 reference mnemonics + expected seeds (empty passphrase).
+    const MNEMONIC_24_ZERO: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art";
+    const SEED_24_ZERO_HEX: &str = "408b285c123836004f4b8842c89324c1f01382450c0d439af345ba7fc49acf705489c6fc77dbd4e3dc1dd8cc6bc9f043db8ada1e243c4a0eafb290d399480840";
+
+    const MNEMONIC_12_ZERO: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    const SEED_12_ZERO_HEX: &str = "5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4";
+
+    #[test]
+    fn seed_from_mnemonic_24_words() {
+        let seed = seed_from_mnemonic(MNEMONIC_24_ZERO).expect("valid 24-word mnemonic");
+        let expected = hex_to_bytes(SEED_24_ZERO_HEX);
+        assert_eq!(seed.as_slice(), expected.as_slice());
+    }
+
+    #[test]
+    fn seed_from_mnemonic_12_words() {
+        let seed = seed_from_mnemonic(MNEMONIC_12_ZERO).expect("valid 12-word mnemonic");
+        let expected = hex_to_bytes(SEED_12_ZERO_HEX);
+        assert_eq!(seed.as_slice(), expected.as_slice());
+    }
+
+    #[test]
+    fn root_key_from_mnemonic_matches_seed_path() {
+        let via_mnemonic = root_key_from_mnemonic(MNEMONIC_24_ZERO).expect("valid mnemonic");
+        let seed = seed_from_mnemonic(MNEMONIC_24_ZERO).expect("valid mnemonic");
+        let via_seed = root_key_from_seed(&seed).expect("valid seed");
+        assert_eq!(via_mnemonic, via_seed);
+    }
+
+    #[test]
+    fn rejects_unknown_word() {
+        let err = seed_from_mnemonic(
+            "notaword notaword notaword notaword notaword notaword \
+             notaword notaword notaword notaword notaword notaword",
+        )
+        .expect_err("should reject unknown word");
+        assert!(matches!(err, XhdError::InvalidMnemonic { .. }));
+    }
+
+    #[test]
+    fn rejects_bad_checksum() {
+        // 12 valid words but the last word breaks the checksum
+        // (zero-entropy 12-word mnemonic ends in "about", not "abandon").
+        let err = seed_from_mnemonic(
+            "abandon abandon abandon abandon abandon abandon \
+             abandon abandon abandon abandon abandon abandon",
+        )
+        .expect_err("should reject bad checksum");
+        assert!(matches!(err, XhdError::InvalidMnemonic { .. }));
     }
 }

--- a/crates/algokit_crypto/src/xhd.rs
+++ b/crates/algokit_crypto/src/xhd.rs
@@ -1,0 +1,319 @@
+//! BIP32-Ed25519 hierarchical deterministic key derivation and raw signing.
+//!
+//! This module provides stateless wrappers over the `ed25519-bip32` crate
+//! (sourced from `xHD-Wallet-API-rs`) for deriving extended keys along the
+//! BIP44 path `m/44'/<coin>'/<account>'/0/<key_index>` under the Peikert
+//! derivation scheme, and for signing arbitrary bytes with an already-derived
+//! 96-byte extended private key.
+//!
+//! All operations are stateless: the caller supplies seed or key material and
+//! receives byte arrays in return. Wallet-level concerns such as secret
+//! storage, zeroization, and BIP44 path bookkeeping are the responsibility of
+//! the caller.
+
+use ed25519_bip32::{
+    DerivationScheme, Signature, XPrv,
+    api::{KeyContext as UpstreamKeyContext, key_gen as upstream_key_gen},
+};
+use snafu::Snafu;
+
+pub const HD_SEED_SIZE: usize = 64;
+pub const XPRV_SIZE: usize = 96;
+pub const PUBLIC_KEY_SIZE: usize = 32;
+pub const SIGNATURE_SIZE: usize = 64;
+
+/// Represents errors that can occur during HD wallet derivation or signing.
+#[derive(Debug, Clone, PartialEq, Eq, Snafu)]
+pub enum XhdError {
+    #[snafu(display("Seed must be {expected} bytes (got {found})"))]
+    InvalidSeedLength { expected: usize, found: usize },
+
+    #[snafu(display("Extended private key must be {expected} bytes (got {found})"))]
+    InvalidXprvLength { expected: usize, found: usize },
+
+    #[snafu(display("Extended private key bytes failed verification"))]
+    InvalidXprv,
+}
+
+/// Selects the BIP44 `coin_type` slot used when deriving a key.
+///
+/// [`KeyContext::Address`] selects coin type 283 for Algorand spending and
+/// transaction keys. [`KeyContext::Identity`] selects coin type 0 for Algorand
+/// identity and authentication keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyContext {
+    Address,
+    Identity,
+}
+
+impl From<KeyContext> for UpstreamKeyContext {
+    fn from(value: KeyContext) -> Self {
+        match value {
+            KeyContext::Address => UpstreamKeyContext::Address,
+            KeyContext::Identity => UpstreamKeyContext::Identity,
+        }
+    }
+}
+
+/// Represents the result of deriving an account at a BIP44 leaf.
+///
+/// Contains the 96-byte extended private key (32-byte scalar, 32-byte prefix,
+/// and 32-byte chain code) and the corresponding 32-byte ed25519 public key.
+#[derive(Debug, Clone)]
+pub struct DerivedAccount {
+    /// Extended private key: 32-byte scalar, 32-byte prefix, 32-byte chain code.
+    pub xprv: [u8; XPRV_SIZE],
+    /// Ed25519 public key derived from the extended private key.
+    pub public_key: [u8; PUBLIC_KEY_SIZE],
+}
+
+/// Derives a 96-byte root extended private key from a 64-byte seed.
+///
+/// The caller owns the returned bytes and is responsible for storage and zeroization.
+///
+/// # Errors
+///
+/// Returns [`XhdError::InvalidSeedLength`] if `seed` is not exactly [`HD_SEED_SIZE`] bytes.
+pub fn root_key_from_seed(seed: &[u8]) -> Result<[u8; XPRV_SIZE], XhdError> {
+    if seed.len() != HD_SEED_SIZE {
+        return Err(XhdError::InvalidSeedLength {
+            expected: HD_SEED_SIZE,
+            found: seed.len(),
+        });
+    }
+
+    let seed_array: [u8; HD_SEED_SIZE] =
+        seed.try_into().map_err(|_| XhdError::InvalidSeedLength {
+            expected: HD_SEED_SIZE,
+            found: seed.len(),
+        })?;
+
+    let xprv = XPrv::from_seed(&seed_array);
+    Ok(xprv.into())
+}
+
+/// Derives an extended private key at the BIP44 path
+/// `m/44'/<coin>'/<account>'/0/<key_index>` using the Peikert derivation scheme.
+///
+/// The `coin` segment is determined by `key_context`: 283 for [`KeyContext::Address`]
+/// and 0 for [`KeyContext::Identity`].
+///
+/// # Errors
+///
+/// Returns [`XhdError::InvalidXprvLength`] if `root_key` is not exactly [`XPRV_SIZE`]
+/// bytes, or [`XhdError::InvalidXprv`] if the bytes do not form a valid extended
+/// private key.
+pub fn derive(
+    root_key: &[u8],
+    key_context: KeyContext,
+    account: u32,
+    key_index: u32,
+) -> Result<DerivedAccount, XhdError> {
+    let root_xprv = parse_xprv(root_key)?;
+
+    let derived = upstream_key_gen(
+        &root_xprv,
+        key_context.into(),
+        account,
+        key_index,
+        DerivationScheme::Peikert,
+    )
+    .map_err(|_| XhdError::InvalidXprv)?;
+
+    let public_key = derived.public().public_key();
+    let xprv: [u8; XPRV_SIZE] = derived.into();
+
+    Ok(DerivedAccount { xprv, public_key })
+}
+
+/// Signs `msg` with an already-derived 96-byte extended private key.
+///
+/// Unlike standard ed25519 signing, this function does not perform the
+/// seed-expansion step on `extended_key`: BIP32-Ed25519 keys are already in
+/// expanded form, and re-hashing them would corrupt the signing material.
+///
+/// # Errors
+///
+/// Returns [`XhdError::InvalidXprvLength`] if `extended_key` is not exactly
+/// [`XPRV_SIZE`] bytes, or [`XhdError::InvalidXprv`] if the bytes do not form
+/// a valid extended private key.
+pub fn raw_sign(extended_key: &[u8], msg: &[u8]) -> Result<[u8; SIGNATURE_SIZE], XhdError> {
+    let xprv = parse_xprv(extended_key)?;
+    let signature: Signature<Vec<u8>> = xprv.sign(msg);
+
+    let mut out = [0u8; SIGNATURE_SIZE];
+    out.copy_from_slice(signature.as_ref());
+    Ok(out)
+}
+
+fn parse_xprv(bytes: &[u8]) -> Result<XPrv, XhdError> {
+    if bytes.len() != XPRV_SIZE {
+        return Err(XhdError::InvalidXprvLength {
+            expected: XPRV_SIZE,
+            found: bytes.len(),
+        });
+    }
+    XPrv::from_slice_verified(bytes).map_err(|_| XhdError::InvalidXprv)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Vectors copied from xHD-Wallet-API-rs/src/api.rs.
+    const SEED_HEX: &str = "3aff2db416b895ec3cf9a4f8d1e970bc9819920e7bf44a5e350477af0ef557b1511b0986debf78dd38c7c520cd44ff7c7231618f958e21ef0250733a8c1915ea";
+    const ROOT_KEY_HEX: &str = "a8ba80028922d9fcfa055c78aede55b5c575bcd8d5a53168edf45f36d9ec8f4694592b4bc892907583e22669ecdf1b0409a9f3bd5549f2dd751b51360909cd05796b9206ec30e142e94b790a98805bf999042b55046963174ee6cee2d0375946";
+
+    fn hex_to_bytes(hex: &str) -> Vec<u8> {
+        (0..hex.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn root_key_from_known_seed() {
+        let seed = hex_to_bytes(SEED_HEX);
+        let root_key = root_key_from_seed(&seed).expect("valid seed");
+        let expected = hex_to_bytes(ROOT_KEY_HEX);
+        assert_eq!(root_key.as_slice(), expected.as_slice());
+    }
+
+    #[test]
+    fn rejects_wrong_seed_length() {
+        let err = root_key_from_seed(&[0u8; 32]).expect_err("should reject 32B seed");
+        assert_eq!(
+            err,
+            XhdError::InvalidSeedLength {
+                expected: 64,
+                found: 32
+            }
+        );
+    }
+
+    #[test]
+    fn address_derivation_vectors() {
+        let root_key = hex_to_bytes(ROOT_KEY_HEX);
+        let cases = [
+            (
+                0u32,
+                0u32,
+                "7bda7ac12627b2c259f1df6875d30c10b35f55b33ad2cc8ea2736eaa3ebcfab9",
+            ),
+            (
+                0,
+                1,
+                "5bae8828f111064637ac5061bd63bc4fcfe4a833252305f25eeab9c64ecdf519",
+            ),
+            (
+                0,
+                2,
+                "00a72635e97cba966529e9bfb4baf4a32d7b8cd2fcd8e2476ce5be1177848cb3",
+            ),
+            (
+                1,
+                0,
+                "358d8c4382992849a764438e02b1c45c2ca4e86bbcfe10fd5b963f3610012bc9",
+            ),
+            (
+                2,
+                1,
+                "1f0f75fbbca12b22523973191061b2f96522740e139a3420c730717ac5b0dfc0",
+            ),
+            (
+                3,
+                0,
+                "f035316f915b342ea5fe78dccb59d907b93805732219d436a1bd8488ff4e5b1b",
+            ),
+        ];
+
+        for (account, key_index, expected_hex) in cases {
+            let derived = derive(&root_key, KeyContext::Address, account, key_index)
+                .expect("derivation succeeds");
+            let expected = hex_to_bytes(expected_hex);
+            assert_eq!(
+                derived.public_key.as_slice(),
+                expected.as_slice(),
+                "Address account={} key_index={}",
+                account,
+                key_index
+            );
+            assert_eq!(derived.xprv.len(), XPRV_SIZE);
+        }
+    }
+
+    #[test]
+    fn identity_derivation_vectors() {
+        let root_key = hex_to_bytes(ROOT_KEY_HEX);
+        let cases = [
+            (
+                0u32,
+                0u32,
+                "ff8b1863ef5e40d0a48c245f26a6dbdf5da94dc75a1851f51d8a04e547bd5f5a",
+            ),
+            (
+                0,
+                1,
+                "2b46c2af0890493e486049d456509a0199e565b41a5fb622f0ea4b9337bd2b97",
+            ),
+            (
+                0,
+                2,
+                "2713f135f19ef3dcfca73cb536b1e077b1165cd0b7bedbef709447319ff0016d",
+            ),
+            (
+                1,
+                0,
+                "232847ae1bb95babcaa50c8033fab98f59e4b4ad1d89ac523a90c830e4ceee4a",
+            ),
+            (
+                2,
+                1,
+                "8f68b6572860d84e8a41e38db1c8c692ded5eb291846f2e5bbfde774a9c6d16e",
+            ),
+        ];
+
+        for (account, key_index, expected_hex) in cases {
+            let derived = derive(&root_key, KeyContext::Identity, account, key_index)
+                .expect("derivation succeeds");
+            let expected = hex_to_bytes(expected_hex);
+            assert_eq!(
+                derived.public_key.as_slice(),
+                expected.as_slice(),
+                "Identity account={} key_index={}",
+                account,
+                key_index
+            );
+        }
+    }
+
+    #[test]
+    fn raw_sign_round_trip() {
+        let root_key = hex_to_bytes(ROOT_KEY_HEX);
+        let derived = derive(&root_key, KeyContext::Address, 0, 0).expect("derivation succeeds");
+
+        let message = b"Hello, Algorand!";
+        let signature = raw_sign(&derived.xprv, message).expect("sign succeeds");
+        assert_eq!(signature.len(), SIGNATURE_SIZE);
+
+        let upstream_xprv = XPrv::from_slice_verified(&derived.xprv).expect("valid xprv");
+        let xpub = upstream_xprv.public();
+        let sig_for_verify = Signature::<u8>::from_slice(&signature).expect("64B signature");
+        assert!(
+            xpub.verify(message, &sig_for_verify),
+            "signature should verify"
+        );
+    }
+
+    #[test]
+    fn raw_sign_rejects_wrong_xprv_length() {
+        let err = raw_sign(&[0u8; 64], b"msg").expect_err("64B is not a valid xprv");
+        assert_eq!(
+            err,
+            XhdError::InvalidXprvLength {
+                expected: 96,
+                found: 64
+            }
+        );
+    }
+}

--- a/crates/algokit_crypto_ffi/src/lib.rs
+++ b/crates/algokit_crypto_ffi/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod algo25;
+pub mod xhd;
 
 use algokit_crypto::ed25519::{
     CryptoxideEd25519Keypair as RustCryptoxideEd25519Keypair, Ed25519Signer as RustEd25519Signer,

--- a/crates/algokit_crypto_ffi/src/xhd.rs
+++ b/crates/algokit_crypto_ffi/src/xhd.rs
@@ -1,0 +1,117 @@
+//! UniFFI bindings for the [`algokit_crypto::xhd`] HD wallet primitives.
+//!
+//! Translates the strongly-typed core API into the byte-vector shape used by
+//! UniFFI host bindings, and maps [`algokit_crypto::xhd::XhdError`] into the
+//! FFI-compatible [`AlgoKitXhdError`].
+
+use algokit_crypto::xhd::{
+    self, DerivedAccount as RustDerivedAccount, KeyContext as RustKeyContext,
+    XhdError as RustXhdError,
+};
+
+/// FFI-compatible mirror of [`algokit_crypto::xhd::KeyContext`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "ffi_uniffi", derive(uniffi::Enum))]
+pub enum XhdKeyContext {
+    Address,
+    Identity,
+}
+
+impl From<XhdKeyContext> for RustKeyContext {
+    fn from(value: XhdKeyContext) -> Self {
+        match value {
+            XhdKeyContext::Address => RustKeyContext::Address,
+            XhdKeyContext::Identity => RustKeyContext::Identity,
+        }
+    }
+}
+
+/// FFI-compatible mirror of [`algokit_crypto::xhd::DerivedAccount`] with byte
+/// vectors in place of fixed-size arrays.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi_uniffi", derive(uniffi::Record))]
+pub struct XhdDerivedAccount {
+    /// Extended private key: 32-byte scalar, 32-byte prefix, 32-byte chain code.
+    pub extended_private_key: Vec<u8>,
+    /// Ed25519 public key derived from the extended private key.
+    pub public_key: Vec<u8>,
+}
+
+impl From<RustDerivedAccount> for XhdDerivedAccount {
+    fn from(value: RustDerivedAccount) -> Self {
+        Self {
+            extended_private_key: value.xprv.to_vec(),
+            public_key: value.public_key.to_vec(),
+        }
+    }
+}
+
+/// FFI-compatible error type for HD wallet operations.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi_uniffi", derive(uniffi::Error))]
+pub enum AlgoKitXhdError {
+    Error { err_msg: String },
+}
+
+impl std::fmt::Display for AlgoKitXhdError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AlgoKitXhdError::Error { err_msg } => write!(f, "{}", err_msg),
+        }
+    }
+}
+
+impl From<RustXhdError> for AlgoKitXhdError {
+    fn from(value: RustXhdError) -> Self {
+        Self::Error {
+            err_msg: value.to_string(),
+        }
+    }
+}
+
+/// Derives a 96-byte root extended private key from a 64-byte seed.
+///
+/// # Errors
+///
+/// Returns an error if `seed` is not exactly 64 bytes.
+#[cfg_attr(feature = "ffi_uniffi", uniffi::export)]
+pub fn xhd_root_key_from_seed(seed: Vec<u8>) -> Result<Vec<u8>, AlgoKitXhdError> {
+    xhd::root_key_from_seed(&seed)
+        .map(|xprv| xprv.to_vec())
+        .map_err(Into::into)
+}
+
+/// Derives an extended private key at the BIP44 path
+/// `m/44'/<coin>'/<account>'/0/<key_index>` using the Peikert derivation scheme.
+///
+/// The `coin` segment is determined by `key_context`: 283 for
+/// [`XhdKeyContext::Address`] and 0 for [`XhdKeyContext::Identity`].
+///
+/// # Errors
+///
+/// Returns an error if `root_key` is not exactly 96 bytes or does not form a
+/// valid extended private key.
+#[cfg_attr(feature = "ffi_uniffi", uniffi::export)]
+pub fn xhd_derive(
+    root_key: Vec<u8>,
+    key_context: XhdKeyContext,
+    account: u32,
+    key_index: u32,
+) -> Result<XhdDerivedAccount, AlgoKitXhdError> {
+    xhd::derive(&root_key, key_context.into(), account, key_index)
+        .map(Into::into)
+        .map_err(Into::into)
+}
+
+/// Signs `msg` with an already-derived 96-byte extended private key.
+///
+/// # Errors
+///
+/// Returns an error if `extended_key` is not exactly 96 bytes or does not form
+/// a valid extended private key.
+#[cfg_attr(feature = "ffi_uniffi", uniffi::export)]
+pub fn xhd_raw_sign(extended_key: Vec<u8>, msg: Vec<u8>) -> Result<Vec<u8>, AlgoKitXhdError> {
+    xhd::raw_sign(&extended_key, &msg)
+        .map(|sig| sig.to_vec())
+        .map_err(Into::into)
+}

--- a/crates/algokit_crypto_ffi/src/xhd.rs
+++ b/crates/algokit_crypto_ffi/src/xhd.rs
@@ -81,6 +81,36 @@ pub fn xhd_root_key_from_seed(seed: Vec<u8>) -> Result<Vec<u8>, AlgoKitXhdError>
         .map_err(Into::into)
 }
 
+/// Derives a 64-byte BIP39 seed from a 12/15/18/21/24-word mnemonic.
+///
+/// The BIP39 passphrase is hardcoded to the empty string; this binding does
+/// not expose passphrase-based derivation.
+///
+/// # Errors
+///
+/// Returns an error if `mnemonic` is not a valid BIP39 phrase.
+#[cfg_attr(feature = "ffi_uniffi", uniffi::export)]
+pub fn xhd_seed_from_mnemonic(mnemonic: String) -> Result<Vec<u8>, AlgoKitXhdError> {
+    xhd::seed_from_mnemonic(&mnemonic)
+        .map(|seed| seed.to_vec())
+        .map_err(Into::into)
+}
+
+/// Derives a 96-byte root extended private key directly from a BIP39 mnemonic.
+///
+/// Convenience wrapper around [`xhd_seed_from_mnemonic`] +
+/// [`xhd_root_key_from_seed`].
+///
+/// # Errors
+///
+/// Returns an error if `mnemonic` is not a valid BIP39 phrase.
+#[cfg_attr(feature = "ffi_uniffi", uniffi::export)]
+pub fn xhd_root_key_from_mnemonic(mnemonic: String) -> Result<Vec<u8>, AlgoKitXhdError> {
+    xhd::root_key_from_mnemonic(&mnemonic)
+        .map(|xprv| xprv.to_vec())
+        .map_err(Into::into)
+}
+
 /// Derives an extended private key at the BIP44 path
 /// `m/44'/<coin>'/<account>'/0/<key_index>` using the Peikert derivation scheme.
 ///


### PR DESCRIPTION
## Proposed Changes

- Add `algokit_crypto::xhd` module: stateless wrappers over `ed25519-bip32` for BIP32-Ed25519 derivation (`root_key_from_seed`, `derive` with Peikert + `KeyContext` for Address/Identity) and `raw_sign`.
- Expose via UniFFI from `algokit_crypto_ffi` as `xhd_root_key_from_seed`, `xhd_derive`, `xhd_raw_sign` with a typed `AlgoKitXhdError`.
- Tests cover upstream Address and Identity derivation vectors plus a sign-and-verify round trip

_Note: wallet state (closures, secret stores, BIP44 path bookkeeping) is left to the host language._
