### PR TITLE
ci: update github action versions

### DIFF
--- a/.github/actions/setup-api-tools/action.yml
+++ b/.github/actions/setup-api-tools/action.yml
@@ -14,10 +14,10 @@ runs:
       with:
         toolchain: 1.85.0
         components: rustfmt
-    
+
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
-    
+      uses: astral-sh/setup-uv@v8.1.0
+
     - name: Install uv dependencies
       working-directory: api/oas_generator
       shell: bash

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -76,7 +76,6 @@ jobs:
           working-directory: ${{ env.ANDROID_PACKAGE_DIR }}
 
       - name: Archive Build Output
-        if: ${{ inputs.release }}
         uses: actions/upload-artifact@v5
         with:
           name: ${{ env.CRATE }}.aar

--- a/.github/workflows/api_ci.yml
+++ b/.github/workflows/api_ci.yml
@@ -31,7 +31,7 @@ jobs:
   oas_lint_and_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-api-tools
 
       - name: Run OAS generator linting
@@ -52,7 +52,7 @@ jobs:
           - client: indexer
             output_dir: crates/indexer_client
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-api-tools
 
       - name: Generate ${{ matrix.client }} API client

--- a/.github/workflows/api_openapi_sync.yml
+++ b/.github/workflows/api_openapi_sync.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         spec: [algod, indexer, kmd]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-api-tools
 
       - uses: actions/setup-node@v5

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -25,7 +25,7 @@ jobs:
       # Ensure output is not buffered for immediate feedback
       RUST_BACKTRACE: 1
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
       - uses: dtolnay/rust-toolchain@master
@@ -34,7 +34,7 @@ jobs:
           components: clippy, rustfmt
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install algokit CLI
         run: uv tool install algokit

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -17,7 +17,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/polytest_validate.yml
+++ b/.github/workflows/polytest_validate.yml
@@ -21,7 +21,7 @@ jobs:
         shell: bash
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.85.0

--- a/.github/workflows/python_uniffi_ci_cd.yml
+++ b/.github/workflows/python_uniffi_ci_cd.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           app-id: ${{ secrets.BOT_ID }}
           private-key: ${{ secrets.BOT_SK }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
           token: ${{ steps.app_token.outputs.token }}
@@ -112,7 +112,7 @@ jobs:
           - name: aarch64-apple-darwin
             runner: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
       - uses: dtolnay/rust-toolchain@master
@@ -180,7 +180,7 @@ jobs:
       TARGET: ${{ matrix.arch == 'ppc64le' && 'powerpc64le' || matrix.arch }}-unknown-linux-${{ matrix.libc }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
 
@@ -262,7 +262,7 @@ jobs:
           app-id: ${{ secrets.BOT_ID }}
           private-key: ${{ secrets.BOT_SK }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
 
@@ -299,7 +299,7 @@ jobs:
         with:
           app-id: ${{ secrets.BOT_ID }}
           private-key: ${{ secrets.BOT_SK }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0

--- a/.github/workflows/swift_ci.yml
+++ b/.github/workflows/swift_ci.yml
@@ -48,7 +48,7 @@ jobs:
         shell: bash
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.85.0
@@ -100,11 +100,9 @@ jobs:
         run: cd packages/swift/${{ env.PACKAGE }} && xcodebuild -scheme ${{ env.PACKAGE }} test -destination "platform=macOS,variant=Mac Catalyst"
 
       - name: Zip Swift package
-        if: inputs.release
         run: cd packages/swift && zip -r ${{ env.PACKAGE }}.zip ${{ env.PACKAGE }} -x "${{ env.PACKAGE }}/.build/*"
 
       - name: Upload Swift package artifact
-        if: inputs.release
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PACKAGE }}


### PR DESCRIPTION
## Proposed Changes
- Update soon to be deprecated github actions
- upload new `aar` and `xcframework` artifact to github action jobs on PR branch updates (maybe be useful for testing purposes)
