### PR TITLE
feat(transact-ffi): add wallet SDK helpers and SuggestedParams record

### DIFF
--- a/crates/algokit_transact_ffi/polytest.toml
+++ b/crates/algokit_transact_ffi/polytest.toml
@@ -35,6 +35,10 @@ groups = ["Transaction Tests"]
 desc = "Tests for state proof transactions"
 groups = ["Transaction Tests"]
 
+[suite."Wallet SDK Helpers"]
+desc = "Tests for helpers consumed by the AlgoKit wallet SDK"
+groups = ["Wallet SDK Helper Tests"]
+
 # Test Group: Generic Transaction Tests
 
 [group."Generic Transaction Tests"]
@@ -100,6 +104,23 @@ desc = "A collection of transactions can be encoded"
 
 [group."Transaction Group Tests".test."encode signed transactions"]
 desc = "A collection of signed transactions can be encoded"
+
+# Test Group: Wallet SDK Helper Tests
+
+[group."Wallet SDK Helper Tests"]
+desc = "Tests for wallet SDK helper functions"
+
+[group."Wallet SDK Helper Tests".test."valid algorand address"]
+desc = "A well-formed Algorand address is reported as valid"
+
+[group."Wallet SDK Helper Tests".test."invalid algorand address"]
+desc = "Malformed or wrong-length strings are reported as invalid addresses"
+
+[group."Wallet SDK Helper Tests".test."receiver min balance fee shortfall"]
+desc = "The top-up equals the shortfall when the receiver is below its minimum balance"
+
+[group."Wallet SDK Helper Tests".test."receiver min balance fee covered"]
+desc = "No top-up is required when the receiver already meets or exceeds its minimum balance"
 
 
 # Test Targets

--- a/crates/algokit_transact_ffi/src/lib.rs
+++ b/crates/algokit_transact_ffi/src/lib.rs
@@ -118,6 +118,27 @@ pub struct FeeParams {
 }
 
 #[ffi_record]
+pub struct SuggestedParams {
+    /// Fee in microALGO. Used as-is when `flat_fee` is true, else a per-byte rate.
+    pub fee: u64,
+
+    /// When true, `fee` is applied as-is; when false, it is a per-byte rate.
+    pub flat_fee: bool,
+
+    /// First round for which the transaction is valid.
+    pub first_round_valid: u64,
+
+    /// Last round for which the transaction is valid.
+    pub last_round_valid: u64,
+
+    /// 32-byte genesis hash that pins the transaction to a specific chain.
+    pub genesis_hash: Vec<u8>,
+
+    /// Genesis ID (e.g. `"mainnet-v1.0"`).
+    pub genesis_id: String,
+}
+
+#[ffi_record]
 pub struct Transaction {
     /// The type of transaction
     transaction_type: TransactionType,
@@ -593,6 +614,12 @@ pub fn public_key_from_address(address: &str) -> Result<Vec<u8>, AlgoKitTransact
         .map(|a| a.as_bytes().to_vec())?)
 }
 
+/// Returns whether the given string parses as a valid Algorand address.
+#[ffi_func]
+pub fn is_valid_algorand_address(address: &str) -> bool {
+    address.parse::<algokit_transact::Address>().is_ok()
+}
+
 /// Get the raw 32-byte transaction ID for a transaction.
 #[ffi_func]
 pub fn get_transaction_id_raw(transaction: Transaction) -> Result<Vec<u8>, AlgoKitTransactError> {
@@ -714,6 +741,15 @@ pub fn assign_fee(
     Ok(updated_txn.into())
 }
 
+/// Returns the additional microALGO the sender must include so the receiver clears its minimum balance, or 0 if it already does.
+#[ffi_func]
+pub fn get_receiver_min_balance_fee(
+    receiver_algo_amount: u64,
+    receiver_min_balance_amount: u64,
+) -> u64 {
+    receiver_min_balance_amount.saturating_sub(receiver_algo_amount)
+}
+
 /// Decodes a signed transaction.
 ///
 /// # Parameters
@@ -806,5 +842,27 @@ mod tests {
         for grouped_tx in grouped_txs.into_iter() {
             assert_eq!(grouped_tx.group.unwrap(), &expected_group);
         }
+    }
+
+    #[test]
+    fn test_is_valid_algorand_address_ffi() {
+        let valid = algokit_transact::Address::new([0u8; 32]).to_string();
+        assert!(is_valid_algorand_address(&valid));
+
+        assert!(!is_valid_algorand_address(""));
+        assert!(!is_valid_algorand_address("not-an-address"));
+        // Right length, but invalid base32 / checksum
+        assert!(!is_valid_algorand_address(&"A".repeat(58)));
+    }
+
+    #[test]
+    fn test_get_receiver_min_balance_fee_ffi() {
+        // Receiver below minimum -> top-up equals the shortfall
+        assert_eq!(get_receiver_min_balance_fee(0, 100_000), 100_000);
+        assert_eq!(get_receiver_min_balance_fee(40_000, 100_000), 60_000);
+
+        // Receiver at or above minimum -> no top-up needed
+        assert_eq!(get_receiver_min_balance_fee(100_000, 100_000), 0);
+        assert_eq!(get_receiver_min_balance_fee(250_000, 100_000), 0);
     }
 }

--- a/crates/algokit_transact_ffi/test_plan.md
+++ b/crates/algokit_transact_ffi/test_plan.md
@@ -49,6 +49,12 @@
 | --- | --- |
 | [Transaction Tests](#transaction-tests) | Tests that apply to all transaction types |
 
+### Wallet Sdk Helpers
+
+| Name | Description |
+| --- | --- |
+| [Wallet SDK Helper Tests](#wallet-sdk-helper-tests) | Tests for wallet SDK helper functions |
+
 ## Test Groups
 
 ### Generic Transaction Tests
@@ -80,6 +86,15 @@
 | [group transactions](#group-transactions) | A collection of transactions can be grouped |
 | [encode transactions](#encode-transactions) | A collection of transactions can be encoded |
 | [encode signed transactions](#encode-signed-transactions) | A collection of signed transactions can be encoded |
+
+### Wallet Sdk Helper Tests
+
+| Name | Description |
+| --- | --- |
+| [valid algorand address](#valid-algorand-address) | A well-formed Algorand address is reported as valid |
+| [invalid algorand address](#invalid-algorand-address) | Malformed or wrong-length strings are reported as invalid addresses |
+| [receiver min balance fee shortfall](#receiver-min-balance-fee-shortfall) | The top-up equals the shortfall when the receiver is below its minimum balance |
+| [receiver min balance fee covered](#receiver-min-balance-fee-covered) | No top-up is required when the receiver already meets or exceeds its minimum balance |
 
 ## Test Cases
 
@@ -142,3 +157,19 @@ A collection of transactions can be encoded
 ### encode signed transactions
 
 A collection of signed transactions can be encoded
+
+### valid algorand address
+
+A well-formed Algorand address is reported as valid
+
+### invalid algorand address
+
+Malformed or wrong-length strings are reported as invalid addresses
+
+### receiver min balance fee shortfall
+
+The top-up equals the shortfall when the receiver is below its minimum balance
+
+### receiver min balance fee covered
+
+No top-up is required when the receiver already meets or exceeds its minimum balance

--- a/packages/python/algokit_transact/tests/test_wallet_sdk_helpers.py
+++ b/packages/python/algokit_transact/tests/test_wallet_sdk_helpers.py
@@ -1,0 +1,39 @@
+import pytest
+from algokit_transact import (
+    address_from_public_key,
+    get_receiver_min_balance_fee,
+    is_valid_algorand_address,
+)
+
+# Polytest Suite: Wallet SDK Helpers
+
+# Polytest Group: Wallet SDK Helper Tests
+
+@pytest.mark.group_wallet_sdk_helper_tests
+def test_valid_algorand_address():
+    """A well-formed Algorand address is reported as valid"""
+    valid = address_from_public_key(bytes(32))
+    assert is_valid_algorand_address(valid)
+
+
+@pytest.mark.group_wallet_sdk_helper_tests
+def test_invalid_algorand_address():
+    """Malformed or wrong-length strings are reported as invalid addresses"""
+    assert not is_valid_algorand_address("")
+    assert not is_valid_algorand_address("not-an-address")
+    # Right length, but invalid base32 / checksum
+    assert not is_valid_algorand_address("A" * 58)
+
+
+@pytest.mark.group_wallet_sdk_helper_tests
+def test_receiver_min_balance_fee_shortfall():
+    """The top-up equals the shortfall when the receiver is below its minimum balance"""
+    assert get_receiver_min_balance_fee(0, 100_000) == 100_000
+    assert get_receiver_min_balance_fee(40_000, 100_000) == 60_000
+
+
+@pytest.mark.group_wallet_sdk_helper_tests
+def test_receiver_min_balance_fee_covered():
+    """No top-up is required when the receiver already meets or exceeds its minimum balance"""
+    assert get_receiver_min_balance_fee(100_000, 100_000) == 0
+    assert get_receiver_min_balance_fee(250_000, 100_000) == 0


### PR DESCRIPTION
Adds three pieces to algokit_transact_ffi that the AlgoKit wallet SDK (KMP/Swift) needs to drop its legacy SDK dependencies: an is_valid_algorand_address validator, a get_receiver_min_balance_fee shortfall helper, and a shared SuggestedParams FFI record carrying the six network-fetched fields (fee, flat_fee, first_round_valid, last_round_valid, genesis_hash, genesis_id) consumed by every transaction builder. All three are stateless functions / pure data — no Rust-owned state crosses the FFI boundary.

Closes #316 and #310. The SuggestedParams record is the shared dependency for the upcoming payment, asset opt-in, and key-registration builder PRs (#311, #312, #313, #314, #315). Test coverage: 2 new Rust unit tests, 4 new polytest catalog entries with implemented Python tests under packages/python/algokit_transact/tests/test_wallet_sdk_helpers.py. Verified all 235 tests pass.