### PR TITLE
feat(transact-ffi): add sign_algo25_transaction

### DIFF
--- a/crates/algokit_transact_ffi/polytest.toml
+++ b/crates/algokit_transact_ffi/polytest.toml
@@ -35,6 +35,10 @@ groups = ["Transaction Tests"]
 desc = "Tests for state proof transactions"
 groups = ["Transaction Tests"]
 
+[suite."Wallet SDK Helpers"]
+desc = "Tests for helpers consumed by the AlgoKit wallet SDK"
+groups = ["Wallet SDK Helper Tests"]
+
 # Test Group: Generic Transaction Tests
 
 [group."Generic Transaction Tests"]
@@ -100,6 +104,14 @@ desc = "A collection of transactions can be encoded"
 
 [group."Transaction Group Tests".test."encode signed transactions"]
 desc = "A collection of signed transactions can be encoded"
+
+# Test Group: Wallet SDK Helper Tests
+
+[group."Wallet SDK Helper Tests"]
+desc = "Tests for wallet SDK helper functions"
+
+[group."Wallet SDK Helper Tests".test."sign algo25 transaction"]
+desc = "An encoded transaction signed via sign_algo25_transaction matches the canonical signed-transaction encoding"
 
 
 # Test Targets

--- a/crates/algokit_transact_ffi/src/lib.rs
+++ b/crates/algokit_transact_ffi/src/lib.rs
@@ -10,7 +10,7 @@ use ffi_macros::{ffi_enum, ffi_func, ffi_record};
 use serde::{Deserialize, Serialize};
 
 pub use multisig::{MultisigSignature, MultisigSubsignature};
-pub use signer::ed25519_sign_transaction;
+pub use signer::{ed25519_sign_transaction, sign_algo25_transaction};
 pub use transactions::AppCallTransactionFields;
 pub use transactions::AssetConfigTransactionFields;
 pub use transactions::AssetFreezeTransactionFields;

--- a/crates/algokit_transact_ffi/src/signer.rs
+++ b/crates/algokit_transact_ffi/src/signer.rs
@@ -58,3 +58,32 @@ pub fn ed25519_sign_transaction(
         multisignature: None,
     })
 }
+
+/// Signs an encoded Algo25 transaction with the given 32-byte Ed25519 secret key and returns the MsgPack-encoded SignedTransaction.
+#[uniffi::export]
+pub fn sign_algo25_transaction(
+    secret_key: Vec<u8>,
+    transaction_bytes: Vec<u8>,
+) -> Result<Vec<u8>, AlgoKitTransactError> {
+    let txn = crate::decode_transaction(&transaction_bytes)?;
+    let signed = ed25519_sign_transaction(secret_key, txn)?;
+    crate::encode_signed_transaction(signed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use algokit_transact::test_utils::TestDataMother;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_sign_algo25_transaction_matches_fixture() {
+        let data = TestDataMother::simple_payment();
+
+        let signed =
+            sign_algo25_transaction(data.signing_private_key.to_vec(), data.unsigned_bytes)
+                .unwrap();
+
+        assert_eq!(signed, data.signed_bytes);
+    }
+}

--- a/crates/algokit_transact_ffi/test_plan.md
+++ b/crates/algokit_transact_ffi/test_plan.md
@@ -49,6 +49,12 @@
 | --- | --- |
 | [Transaction Tests](#transaction-tests) | Tests that apply to all transaction types |
 
+### Wallet Sdk Helpers
+
+| Name | Description |
+| --- | --- |
+| [Wallet SDK Helper Tests](#wallet-sdk-helper-tests) | Tests for wallet SDK helper functions |
+
 ## Test Groups
 
 ### Generic Transaction Tests
@@ -80,6 +86,12 @@
 | [group transactions](#group-transactions) | A collection of transactions can be grouped |
 | [encode transactions](#encode-transactions) | A collection of transactions can be encoded |
 | [encode signed transactions](#encode-signed-transactions) | A collection of signed transactions can be encoded |
+
+### Wallet Sdk Helper Tests
+
+| Name | Description |
+| --- | --- |
+| [sign algo25 transaction](#sign-algo-25-transaction) | An encoded transaction signed via sign_algo25_transaction matches the canonical signed-transaction encoding |
 
 ## Test Cases
 
@@ -142,3 +154,7 @@ A collection of transactions can be encoded
 ### encode signed transactions
 
 A collection of signed transactions can be encoded
+
+### sign algo25 transaction
+
+An encoded transaction signed via sign_algo25_transaction matches the canonical signed-transaction encoding

--- a/packages/python/algokit_transact/tests/test_wallet_sdk_helpers.py
+++ b/packages/python/algokit_transact/tests/test_wallet_sdk_helpers.py
@@ -1,0 +1,16 @@
+import pytest
+from . import TEST_DATA
+from algokit_transact import sign_algo25_transaction
+
+# Polytest Suite: Wallet SDK Helpers
+
+# Polytest Group: Wallet SDK Helper Tests
+
+@pytest.mark.group_wallet_sdk_helper_tests
+def test_sign_algo_25_transaction():
+    """An encoded transaction signed via sign_algo25_transaction matches the canonical signed-transaction encoding"""
+    data = TEST_DATA.simple_payment
+    signed = sign_algo25_transaction(
+        bytes(data.signing_private_key), data.unsigned_bytes
+    )
+    assert signed == data.signed_bytes


### PR DESCRIPTION
Adds `sign_algo25_transaction` to `algokit_transact_ffi`, a thin wallet SDK convenience that composes the existing decode_transaction → ed25519_sign_transaction → encode_signed_transaction pipeline. The function takes a 32-byte Ed25519 secret key plus an encoded transaction blob and returns the msgpack-encoded SignedTransaction ready for submission — matching the return shape the AlgoKit wallet SDK (KMP/Swift).

Closes #309. Test coverage: a new Rust unit test (test_sign_algo25_transaction_matches_fixture) that signs a real TestDataMother::simple_payment fixture and asserts the output equals the canonical signed_bytes for that fixture; a polytest catalog entry under the "Wallet SDK Helpers" suite with an implemented Python test against the same fixture. Verified 234 tests passed.